### PR TITLE
feat: export `within` function with shadow queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ import { render } from "@testing-library/react"
 import { screen } from "shadow-dom-testing-library"
 
 test("Lets test some rendering", () => {
-  render(<Button />
+  render(<Button />)
   screen.getByShadowRole("button")
   await screen.findByShadowLabelText(/Car Manufacturer/i)
   screen.queryAllByShadowTitle("delete")
@@ -115,6 +115,22 @@ import { deepQuerySelector, deepQuerySelectorAll } from "shadow-dom-testing-libr
 const elements = deepQuerySelectorAll(document, "my-button")
 const element = deepQuerySelector(document, "my-button", { shallow: true })
 ```
+
+A `within` function is exported to provide the `<ByShadow>` queries
+bound to a particular container element.
+
+```jsx
+import { render } from "@testing-library/react"
+import { screen, within } from "shadow-dom-testing-library"
+
+test("Lets test some rendering", () => {
+  render(<ComplicatedControl />)
+  const fieldGroup = screen.getByShadowRole("group")
+
+  const nameInput = within(fieldGroup).getByShadowRole('textbox', { name: 'foobar' });
+})
+```
+
 
 ## Caution
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {waitForOptions, buildQueries, screen, ByRoleMatcher, ByRoleOptions, queryAllByRole, SelectorMatcherOptions, queryAllByLabelText, Matcher, queryAllByPlaceholderText, MatcherOptions, queryAllByText, queryAllByDisplayValue, queryAllByAltText, queryAllByTitle, queryAllByTestId} from '@testing-library/dom'
+import {waitForOptions, buildQueries, screen, ByRoleMatcher, ByRoleOptions, queryAllByRole, SelectorMatcherOptions, queryAllByLabelText, Matcher, queryAllByPlaceholderText, MatcherOptions, queryAllByText, queryAllByDisplayValue, queryAllByAltText, queryAllByTitle, queryAllByTestId, queries, within} from '@testing-library/dom'
 
 export type Container = HTMLElement | Document | ShadowRoot
 
@@ -388,8 +388,82 @@ let myScreen = {
   findByShadowTestId: (...args: AsyncScreenShadowMatcherParams) => findByShadowTestId(document.documentElement, args[0], args[1], args[2]),
 }
 
+const allQueries = {
+  ...queries,
+
+  // Role
+  queryAllByShadowRole,
+  queryByShadowRole,
+  getAllByShadowRole,
+  getByShadowRole,
+  findAllByShadowRole,
+  findByShadowRole,
+
+  // Label Text
+  queryAllByShadowLabelText,
+  queryByShadowLabelText,
+  getAllByShadowLabelText,
+  getByShadowLabelText,
+  findAllByShadowLabelText,
+  findByShadowLabelText,
+
+  // Placeholder Text
+  queryAllByShadowPlaceholderText,
+  queryByShadowPlaceholderText,
+  getAllByShadowPlaceholderText,
+  getByShadowPlaceholderText,
+  findAllByShadowPlaceholderText,
+  findByShadowPlaceholderText,
+
+  // Text
+  queryAllByShadowText,
+  queryByShadowText,
+  getAllByShadowText,
+  getByShadowText,
+  findAllByShadowText,
+  findByShadowText,
+
+  // Display Value
+  queryAllByShadowDisplayValue,
+  queryByShadowDisplayValue,
+  getAllByShadowDisplayValue,
+  getByShadowDisplayValue,
+  findAllByShadowDisplayValue,
+  findByShadowDisplayValue,
+
+  // Alt Text
+  queryAllByShadowAltText,
+  queryByShadowAltText,
+  getAllByShadowAltText,
+  getByShadowAltText,
+  findAllByShadowAltText,
+  findByShadowAltText,
+
+  // Title
+  queryAllByShadowTitle,
+  queryByShadowTitle,
+  getAllByShadowTitle,
+  getByShadowTitle,
+  findAllByShadowTitle,
+  findByShadowTitle,
+
+  // Test Id
+  queryAllByShadowTestId,
+  queryByShadowTestId,
+  getAllByShadowTestId,
+  getByShadowTestId,
+  findAllByShadowTestId,
+  findByShadowTestId,
+};
+
+function customWithin(element: HTMLElement) {
+  return within(element, allQueries);
+}
+
 export {
   myScreen as screen,
+
+  customWithin as within,
 
   // Role
   queryAllByShadowRole,


### PR DESCRIPTION
* Exports a `within` function containing all the normal AND
  shadow queries to make querying shadow elements in a particular
  container easier

* Updates documentation with new `within` function