### PR TITLE
fix: 'within' now pushes to host element into the array of elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ and internally calls `prettyShadowDOM`. This is called via `screen.debug()`
 ### Example of logShadowDOM
 
 ```js
-import { logShadowDOM } from "shadow-dom-testing-library"
+import { logShadowDOM } from "shadow-dom-testing-library";
 
-logShadowDOM(element, maxLength, options) // void; calls console.log()
+logShadowDOM(element, maxLength, options); // void; calls console.log()
 ```
 
 ## prettyShadowDOM
@@ -247,7 +247,7 @@ This is useful for custom error messages for elements.
 ### Example of prettyShadowDOM
 
 ```js
-import { prettyShadowDOM } from "shadow-dom-testing-library"
+import { prettyShadowDOM } from "shadow-dom-testing-library";
 
-prettyShadowDOM(element, maxLength, options) // => string | false
+prettyShadowDOM(element, maxLength, options); // => string | false
 ```

--- a/__tests__/duplicateNodes.test.tsx
+++ b/__tests__/duplicateNodes.test.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { screen } from "../src/index";
-import { Duplicates, NestedShadowRoots, TripleShadowRoots } from "../components";
+import {
+  Duplicates,
+  NestedShadowRoots,
+  TripleShadowRoots,
+} from "../components";
 
 // @see https://github.com/KonnorRogers/shadow-dom-testing-library/issues/10
 test("Should only return 1 node instead of checking both", async () => {
@@ -33,19 +37,19 @@ test("Should error if two similar nodes are in shadow root", async () => {
 });
 
 test("Should find duplicate nodes in a double nested shadow root", async () => {
-	render(<NestedShadowRoots />)
+  render(<NestedShadowRoots />);
 
   expect(() => screen.getByShadowRole("button")).toThrow(/multiple elements/i);
   await expect(() => screen.findByShadowRole("button")).rejects.toThrow(
     /multiple elements/i
   );
-})
+});
 
 test("Should find duplicate nodes in a triple nested shadow root", async () => {
-	render(<TripleShadowRoots />)
+  render(<TripleShadowRoots />);
 
   expect(() => screen.getByShadowRole("button")).toThrow(/multiple elements/i);
   await expect(() => screen.findByShadowRole("button")).rejects.toThrow(
     /multiple elements/i
   );
-})
+});

--- a/__tests__/pretty-shadow-dom.test.ts
+++ b/__tests__/pretty-shadow-dom.test.ts
@@ -1,17 +1,17 @@
-import { prettyShadowDOM } from "../src/index"
+import { prettyShadowDOM } from "../src/index";
 
 test("Should strip style and script tags", () => {
-	const div = document.createElement("div")
-	div.innerHTML = `
+  const div = document.createElement("div");
+  div.innerHTML = `
 		<!-- Comment -->
 		<style>style {}</style>
 		<script>const script = null</script>
 		<div>Hi</div>
-	`
-	const str = prettyShadowDOM(div) as string
+	`;
+  const str = prettyShadowDOM(div) as string;
 
-	expect(str.includes("Comment")).toBe(false)
-	expect(str.includes("style")).toBe(false)
-	expect(str.includes("script")).toBe(false)
-	expect(str.includes("Hi")).toBe(true)
-})
+  expect(str.includes("Comment")).toBe(false);
+  expect(str.includes("style")).toBe(false);
+  expect(str.includes("script")).toBe(false);
+  expect(str.includes("Hi")).toBe(true);
+});

--- a/__tests__/screenDebug.test.tsx
+++ b/__tests__/screenDebug.test.tsx
@@ -1,23 +1,23 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { Duplicates, NestedShadowRoots, TripleShadowRoots } from "../components";
+import {
+  Duplicates,
+  NestedShadowRoots,
+  TripleShadowRoots,
+} from "../components";
 import { screen } from "../src/index";
 
 test.skip("Triple shadow roots", async () => {
-  render(
-  	<TripleShadowRoots />
-  );
+  render(<TripleShadowRoots />);
 
   screen.debug();
-})
+});
 
 test.skip("Double shadow root", async () => {
-  render(
-  	<NestedShadowRoots />
-  );
+  render(<NestedShadowRoots />);
 
   screen.debug();
-})
+});
 
 test.skip("Single shadow root", async () => {
   render(

--- a/__tests__/within.test.tsx
+++ b/__tests__/within.test.tsx
@@ -10,14 +10,14 @@ describe("within", () => {
 
     render(
       <Select label={selectLabel}>
-        <option>Option one</option>
+        <option>{optionLabel}</option>
         <option>Option two</option>
       </Select>
     );
 
-    const shadowSelect = await screen.findByShadowRole("combobox");
-    // 	name: selectLabel
-    // });
+    const shadowSelect = await screen.findByShadowRole("combobox", {
+      name: selectLabel,
+    });
 
     // @ts-expect-error
     const select = shadowSelect.getRootNode().host as MySelect;

--- a/__tests__/within.test.tsx
+++ b/__tests__/within.test.tsx
@@ -15,16 +15,12 @@ describe("within", () => {
       </Select>
     );
 
-    const shadowSelect = await screen.findByShadowRole("combobox", {
-      name: selectLabel,
-    });
+    const shadowSelect = await screen.findByShadowRole("combobox")
 
     // @ts-expect-error
     const select = shadowSelect.getRootNode().host as MySelect;
 
-    const option = within(select).getByShadowRole("option", {
-      name: optionLabel,
-    });
+    const option = within(select).getByShadowRole("option", { name: optionLabel })
     expect(option).toBeInTheDocument();
   });
 });

--- a/__tests__/within.test.tsx
+++ b/__tests__/within.test.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { MySelect, Select } from "../components";
+import { render } from "@testing-library/react";
+import { screen, within } from "../src/index";
+
+describe('within', () => {
+	it("Should allow you to select from both shadow and light dom", async () => {
+		const selectLabel = "Select something"
+		const optionLabel = "Option one"
+
+		render(
+			<Select label={selectLabel}>
+				<option>Option one</option>
+				<option>Option two</option>
+			</Select>
+		)
+
+		const shadowSelect = await screen.findByShadowRole("combobox")
+		// 	name: selectLabel
+		// });
+
+		// @ts-expect-error
+		const select = shadowSelect.getRootNode().host as MySelect;
+
+		const option = within(select).getByShadowRole("option", {
+			name: optionLabel
+		});
+		expect(option).toBeInTheDocument()
+	})
+})

--- a/__tests__/within.test.tsx
+++ b/__tests__/within.test.tsx
@@ -3,28 +3,28 @@ import { MySelect, Select } from "../components";
 import { render } from "@testing-library/react";
 import { screen, within } from "../src/index";
 
-describe('within', () => {
-	it("Should allow you to select from both shadow and light dom", async () => {
-		const selectLabel = "Select something"
-		const optionLabel = "Option one"
+describe("within", () => {
+  it("Should allow you to select from both shadow and light dom", async () => {
+    const selectLabel = "Select something";
+    const optionLabel = "Option one";
 
-		render(
-			<Select label={selectLabel}>
-				<option>Option one</option>
-				<option>Option two</option>
-			</Select>
-		)
+    render(
+      <Select label={selectLabel}>
+        <option>Option one</option>
+        <option>Option two</option>
+      </Select>
+    );
 
-		const shadowSelect = await screen.findByShadowRole("combobox")
-		// 	name: selectLabel
-		// });
+    const shadowSelect = await screen.findByShadowRole("combobox");
+    // 	name: selectLabel
+    // });
 
-		// @ts-expect-error
-		const select = shadowSelect.getRootNode().host as MySelect;
+    // @ts-expect-error
+    const select = shadowSelect.getRootNode().host as MySelect;
 
-		const option = within(select).getByShadowRole("option", {
-			name: optionLabel
-		});
-		expect(option).toBeInTheDocument()
-	})
-})
+    const option = within(select).getByShadowRole("option", {
+      name: optionLabel,
+    });
+    expect(option).toBeInTheDocument();
+  });
+});

--- a/components.tsx
+++ b/components.tsx
@@ -158,10 +158,12 @@ export class MySelect extends HTMLElement {
 		if (this.isConnected === false) return ""
 
     this.shadowRoot.innerHTML = `
-    	<label for="select">${this.label}</label>
-			<select id="select">
-				<slot></slot>
-			</select>
+    	<label>
+				${this.label}
+				<select>
+					<slot></slot>
+				</select>
+			</label>
 		`;
 	}
 }

--- a/components.tsx
+++ b/components.tsx
@@ -136,6 +136,36 @@ class TripleShadowRootsElement extends HTMLElement {
 	}
 }
 
+export class MySelect extends HTMLElement {
+	_label: string = ""
+
+	get label () {
+		return this._label
+	}
+
+	set label (value: string) {
+		this._label = value
+		this.render()
+	}
+
+	connectedCallback () {
+    this.attachShadow({mode: 'open'});
+    this.render()
+	}
+
+	render () {
+		if (this.shadowRoot == null) return ""
+		if (this.isConnected === false) return ""
+
+    this.shadowRoot.innerHTML = `
+    	<label for="select">${this.label}</label>
+			<select id="select">
+				<slot></slot>
+			</select>
+		`;
+	}
+}
+
 /* Custom element declarations */
 type CustomEvents<K extends string> = { [key in K] : (event: CustomEvent) => void };
 type CustomElement<T, K extends string = string> = Partial<T & React.DOMAttributes<T> & { children: any } & CustomEvents<`on${K}`>>;
@@ -146,6 +176,7 @@ window.customElements.define("my-text-area", class extends MyTextArea {})
 window.customElements.define("duplicate-buttons", class extends DuplicateButtons {})
 window.customElements.define("nested-shadow-roots", class extends NestedShadowRootsElement {})
 window.customElements.define("triple-shadow-roots", class extends TripleShadowRootsElement {})
+window.customElements.define("my-select", class extends MySelect {})
 
 declare global {
   namespace JSX {
@@ -156,6 +187,7 @@ declare global {
       ['duplicate-buttons']: CustomElement<DuplicateButtons>;
       ['nested-shadow-roots']: CustomElement<NestedShadowRootsElement>;
       ['triple-shadow-roots']: CustomElement<TripleShadowRootsElement>;
+      ['my-select']: CustomElement<MySelect>
     }
   }
 }
@@ -196,3 +228,4 @@ export const Duplicates = (props: Record<string, any>) => <duplicate-buttons {..
 
 export const NestedShadowRoots = (props: Record<string, any>) => <nested-shadow-roots {...props} />
 export const TripleShadowRoots = (props: Record<string, any>) => <triple-shadow-roots {...props} />
+export const Select = (props: Record<string, any>) => <my-select {...props} />

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "test": "vitest run",
+    "format": "npx prettier ./src ./__tests__ ./README.md --write",
     "test:watch": "vitest",
     "test:ci": "npm run build && npm run test && npm run jest",
     "jest": "jest",

--- a/src/deep-query-selectors.ts
+++ b/src/deep-query-selectors.ts
@@ -26,11 +26,15 @@ export function deepQuerySelectorAll(
     container = document.documentElement;
   }
 
-	// Make sure we're checking the container element!
+  // Make sure we're checking the container element!
   elements.push(container);
 
   // Accounts for if the container houses a textNode
-  if (container instanceof HTMLElement && container.shadowRoot != null && container.shadowRoot.mode !== "closed") {
+  if (
+    container instanceof HTMLElement &&
+    container.shadowRoot != null &&
+    container.shadowRoot.mode !== "closed"
+  ) {
     elements.push(container.shadowRoot);
   }
 
@@ -60,4 +64,3 @@ export function deepQuerySelectorAll(
   // We can sometimes hit duplicate nodes this way, lets stop that.
   return [...new Set(elements)];
 }
-

--- a/src/deep-query-selectors.ts
+++ b/src/deep-query-selectors.ts
@@ -26,14 +26,13 @@ export function deepQuerySelectorAll(
     container = document.documentElement;
   }
 
-  // Accounts for if the container houses a textNode
-  // @ts-expect-error
-  if (container.shadowRoot != null && container.shadowRoot.mode !== "closed")
-   // @ts-expect-error
-    elements.push(container.shadowRoot);
+	// Make sure we're checking the container element!
+  elements.push(container);
 
-  // If you pass in a shadowRoot container, you should still be able to find the text nodes.
-  if (container instanceof ShadowRoot) elements.push(container);
+  // Accounts for if the container houses a textNode
+  if (container instanceof HTMLElement && container.shadowRoot != null && container.shadowRoot.mode !== "closed") {
+    elements.push(container.shadowRoot);
+  }
 
   container.querySelectorAll(selectors).forEach((el: Element | HTMLElement) => {
     if (el.shadowRoot == null || el.shadowRoot.mode === "closed") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,24 @@
-import {
-  queries,
-  within,
-} from "@testing-library/dom";
+import { queries, within } from "@testing-library/dom";
 
-import * as shadowQueries from "./shadow-queries"
+import * as shadowQueries from "./shadow-queries";
 import { debug } from "./debug";
-import { logShadowDOM } from "./log-shadow-dom"
-import { prettyShadowDOM } from "./pretty-shadow-dom"
-import { shadowScreen } from "./shadow-screen"
+import { logShadowDOM } from "./log-shadow-dom";
+import { prettyShadowDOM } from "./pretty-shadow-dom";
+import { shadowScreen } from "./shadow-screen";
 import { trickDOMTestingLibrary } from "./trick-dom-testing-library";
 
 trickDOMTestingLibrary();
 
 const allQueries = {
   ...queries,
-  ...shadowQueries
+  ...shadowQueries,
 };
 
 function shadowWithin(element: HTMLElement) {
   return within(element, allQueries);
 }
 
-export * from "./types"
+export * from "./types";
 export * from "./shadow-queries";
 
 export {
@@ -29,5 +26,5 @@ export {
   shadowWithin as within,
   debug,
   logShadowDOM,
-	prettyShadowDOM
+  prettyShadowDOM,
 };

--- a/src/jsdom-setup.ts
+++ b/src/jsdom-setup.ts
@@ -3,4 +3,3 @@ import { TextEncoder, TextDecoder } from "util";
 /** This is a hack for using JSDOM + Jest. Vitest is unaffected by this. */
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder as typeof global["TextDecoder"];
-

--- a/src/log-shadow-dom.ts
+++ b/src/log-shadow-dom.ts
@@ -1,8 +1,10 @@
 import { logDOM } from "@testing-library/dom";
 import { toJSDOM } from "./pretty-shadow-dom";
 
-export function logShadowDOM(...args: Parameters<typeof logDOM>): ReturnType<typeof logDOM> {
-	const [dom, maxLength, options] = args
+export function logShadowDOM(
+  ...args: Parameters<typeof logDOM>
+): ReturnType<typeof logDOM> {
+  const [dom, maxLength, options] = args;
 
-	logDOM(toJSDOM(dom), maxLength, options)
+  logDOM(toJSDOM(dom), maxLength, options);
 }

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -1,16 +1,18 @@
-import "./jsdom-setup"
+import "./jsdom-setup";
 import { prettyDOM } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 
 /**
  * This is an extension of prettyDOM / logDOM that provides proper printing of shadow roots.
  */
-export function prettyShadowDOM(...args: Parameters<typeof prettyDOM>): ReturnType<typeof prettyDOM> {
-	const [element, maxLength, options] = args
+export function prettyShadowDOM(
+  ...args: Parameters<typeof prettyDOM>
+): ReturnType<typeof prettyDOM> {
+  const [element, maxLength, options] = args;
   return prettyDOM(toJSDOM(element), maxLength, options);
 }
 
-export function toJSDOM (element?: Element | Document | undefined): HTMLElement {
+export function toJSDOM(element?: Element | Document | undefined): HTMLElement {
   if (element == null) element = document.documentElement;
 
   let htmlString: string = "";
@@ -19,7 +21,7 @@ export function toJSDOM (element?: Element | Document | undefined): HTMLElement 
     htmlString = element.outerHTML;
   }
 
-	htmlString = processNodes(element, htmlString, Array.from(element.children))
+  htmlString = processNodes(element, htmlString, Array.from(element.children));
 
   // Remove Comment nodes
   htmlString = htmlString.replace(/<!--.*?-->/g, "");
@@ -31,7 +33,11 @@ export function toJSDOM (element?: Element | Document | undefined): HTMLElement 
   return dom.window.document.body;
 }
 
-function processNodes (element: Element | Document | ShadowRoot, stringBuffer: string = "", nodes: Array<Element | ShadowRoot> = Array.from(element.children)) {
+function processNodes(
+  element: Element | Document | ShadowRoot,
+  stringBuffer: string = "",
+  nodes: Array<Element | ShadowRoot> = Array.from(element.children)
+) {
   while (nodes.length > 0) {
     const node = nodes.shift()!;
     if (node && "shadowRoot" in node && node.shadowRoot != null) {
@@ -50,5 +56,5 @@ function processNodes (element: Element | Document | ShadowRoot, stringBuffer: s
     nodes.push(...Array.from(node.children));
   }
 
-  return stringBuffer
+  return stringBuffer;
 }

--- a/src/shadow-queries.ts
+++ b/src/shadow-queries.ts
@@ -13,7 +13,14 @@ import {
 } from "@testing-library/dom";
 
 import { deepQuerySelectorAll } from "./deep-query-selectors";
-import { ScreenShadowMatcherParams, ScreenShadowRoleMatcherParams, ScreenShadowSelectorMatcherParams, ShadowMatcherParams, ShadowRoleMatcherParams, ShadowSelectorMatcherParams } from "./types";
+import {
+  ScreenShadowMatcherParams,
+  ScreenShadowRoleMatcherParams,
+  ScreenShadowSelectorMatcherParams,
+  ShadowMatcherParams,
+  ShadowRoleMatcherParams,
+  ShadowSelectorMatcherParams,
+} from "./types";
 
 const scopeQuery = "*";
 
@@ -321,8 +328,6 @@ const [
   getMissingTestIdError
 );
 
-
-
 export {
   // Role
   queryAllByShadowRole,
@@ -387,4 +392,4 @@ export {
   getByShadowTestId,
   findAllByShadowTestId,
   findByShadowTestId,
-}
+};

--- a/src/shadow-screen.ts
+++ b/src/shadow-screen.ts
@@ -1,8 +1,15 @@
-import { debug } from "./debug"
-import { screen } from "@testing-library/dom"
+import { debug } from "./debug";
+import { screen } from "@testing-library/dom";
 
-import * as shadowQueries from "./shadow-queries"
-import { AsyncScreenShadowMatcherParams, AsyncScreenShadowRoleMatcherParams, AsyncScreenShadowSelectorMatcherParams, ScreenShadowMatcherParams, ScreenShadowRoleMatcherParams, ScreenShadowSelectorMatcherParams } from "./types";
+import * as shadowQueries from "./shadow-queries";
+import {
+  AsyncScreenShadowMatcherParams,
+  AsyncScreenShadowRoleMatcherParams,
+  AsyncScreenShadowSelectorMatcherParams,
+  ScreenShadowMatcherParams,
+  ScreenShadowRoleMatcherParams,
+  ScreenShadowSelectorMatcherParams,
+} from "./types";
 
 // Shadows the following: https://testing-library.com/docs/queries/about/#priority
 const shadowScreen = {
@@ -10,27 +17,61 @@ const shadowScreen = {
   debug,
   // Role
   queryAllByShadowRole: (...args: ScreenShadowRoleMatcherParams) =>
-    shadowQueries.queryAllByShadowRole(document.documentElement, args[0], args[1]),
+    shadowQueries.queryAllByShadowRole(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   queryByShadowRole: (...args: ScreenShadowRoleMatcherParams) =>
     shadowQueries.queryByShadowRole(document.documentElement, args[0], args[1]),
   getAllByShadowRole: (...args: ScreenShadowRoleMatcherParams) =>
-    shadowQueries.getAllByShadowRole(document.documentElement, args[0], args[1]),
+    shadowQueries.getAllByShadowRole(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getByShadowRole: (...args: ScreenShadowRoleMatcherParams) =>
     shadowQueries.getByShadowRole(document.documentElement, args[0], args[1]),
   findAllByShadowRole: (...args: AsyncScreenShadowRoleMatcherParams) =>
-    shadowQueries.findAllByShadowRole(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findAllByShadowRole(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
   findByShadowRole: (...args: AsyncScreenShadowRoleMatcherParams) =>
-    shadowQueries.findByShadowRole(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findByShadowRole(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
 
   // Label Text
   queryAllByShadowLabelText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.queryAllByShadowLabelText(document.documentElement, args[0], args[1]),
+    shadowQueries.queryAllByShadowLabelText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   queryByShadowLabelText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.queryByShadowLabelText(document.documentElement, args[0], args[1]),
+    shadowQueries.queryByShadowLabelText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getAllByShadowLabelText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.getAllByShadowLabelText(document.documentElement, args[0], args[1]),
+    shadowQueries.getAllByShadowLabelText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getByShadowLabelText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.getByShadowLabelText(document.documentElement, args[0], args[1]),
+    shadowQueries.getByShadowLabelText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   findAllByShadowLabelText: (...args: AsyncScreenShadowSelectorMatcherParams) =>
     shadowQueries.findAllByShadowLabelText(
       document.documentElement,
@@ -39,17 +80,38 @@ const shadowScreen = {
       args[2]
     ),
   findByShadowLabelText: (...args: AsyncScreenShadowSelectorMatcherParams) =>
-    shadowQueries.findByShadowLabelText(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findByShadowLabelText(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
 
   // Placeholder Text
   queryAllByShadowPlaceholderText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowPlaceholderText(document.documentElement, args[0], args[1]),
+    shadowQueries.queryAllByShadowPlaceholderText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   queryByShadowPlaceholderText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowPlaceholderText(document.documentElement, args[0], args[1]),
+    shadowQueries.queryByShadowPlaceholderText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getAllByShadowPlaceholderText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowPlaceholderText(document.documentElement, args[0], args[1]),
+    shadowQueries.getAllByShadowPlaceholderText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getByShadowPlaceholderText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getByShadowPlaceholderText(document.documentElement, args[0], args[1]),
+    shadowQueries.getByShadowPlaceholderText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   findAllByShadowPlaceholderText: (...args: AsyncScreenShadowMatcherParams) =>
     shadowQueries.findAllByShadowPlaceholderText(
       document.documentElement,
@@ -67,27 +129,61 @@ const shadowScreen = {
 
   // Text
   queryAllByShadowText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.queryAllByShadowText(document.documentElement, args[0], args[1]),
+    shadowQueries.queryAllByShadowText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   queryByShadowText: (...args: ScreenShadowSelectorMatcherParams) =>
     shadowQueries.queryByShadowText(document.documentElement, args[0], args[1]),
   getAllByShadowText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.getAllByShadowText(document.documentElement, args[0], args[1]),
+    shadowQueries.getAllByShadowText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getByShadowText: (...args: ScreenShadowSelectorMatcherParams) =>
     shadowQueries.getByShadowText(document.documentElement, args[0], args[1]),
   findAllByShadowText: (...args: AsyncScreenShadowSelectorMatcherParams) =>
-    shadowQueries.findAllByShadowText(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findAllByShadowText(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
   findByShadowText: (...args: AsyncScreenShadowSelectorMatcherParams) =>
-    shadowQueries.findByShadowText(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findByShadowText(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
 
   // Display Value
   queryAllByShadowDisplayValue: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowDisplayValue(document.documentElement, args[0], args[1]),
+    shadowQueries.queryAllByShadowDisplayValue(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   queryByShadowDisplayValue: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowDisplayValue(document.documentElement, args[0], args[1]),
+    shadowQueries.queryByShadowDisplayValue(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getAllByShadowDisplayValue: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowDisplayValue(document.documentElement, args[0], args[1]),
+    shadowQueries.getAllByShadowDisplayValue(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getByShadowDisplayValue: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getByShadowDisplayValue(document.documentElement, args[0], args[1]),
+    shadowQueries.getByShadowDisplayValue(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   findAllByShadowDisplayValue: (...args: AsyncScreenShadowMatcherParams) =>
     shadowQueries.findAllByShadowDisplayValue(
       document.documentElement,
@@ -105,45 +201,115 @@ const shadowScreen = {
 
   // Alt Text
   queryAllByShadowAltText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowAltText(document.documentElement, args[0], args[1]),
+    shadowQueries.queryAllByShadowAltText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   queryByShadowAltText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowAltText(document.documentElement, args[0], args[1]),
+    shadowQueries.queryByShadowAltText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getAllByShadowAltText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowAltText(document.documentElement, args[0], args[1]),
+    shadowQueries.getAllByShadowAltText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getByShadowAltText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getByShadowAltText(document.documentElement, args[0], args[1]),
+    shadowQueries.getByShadowAltText(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   findAllByShadowAltText: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findAllByShadowAltText(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findAllByShadowAltText(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
   findByShadowAltText: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findByShadowAltText(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findByShadowAltText(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
 
   // Title
   queryAllByShadowTitle: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowTitle(document.documentElement, args[0], args[1]),
+    shadowQueries.queryAllByShadowTitle(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   queryByShadowTitle: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowTitle(document.documentElement, args[0], args[1]),
+    shadowQueries.queryByShadowTitle(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getAllByShadowTitle: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowTitle(document.documentElement, args[0], args[1]),
+    shadowQueries.getAllByShadowTitle(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getByShadowTitle: (...args: ScreenShadowMatcherParams) =>
     shadowQueries.getByShadowTitle(document.documentElement, args[0], args[1]),
   findAllByShadowTitle: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findAllByShadowTitle(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findAllByShadowTitle(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
   findByShadowTitle: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findByShadowTitle(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findByShadowTitle(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
 
   // Test Id
   queryAllByShadowTestId: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowTestId(document.documentElement, args[0], args[1]),
+    shadowQueries.queryAllByShadowTestId(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   queryByShadowTestId: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowTestId(document.documentElement, args[0], args[1]),
+    shadowQueries.queryByShadowTestId(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getAllByShadowTestId: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowTestId(document.documentElement, args[0], args[1]),
+    shadowQueries.getAllByShadowTestId(
+      document.documentElement,
+      args[0],
+      args[1]
+    ),
   getByShadowTestId: (...args: ScreenShadowMatcherParams) =>
     shadowQueries.getByShadowTestId(document.documentElement, args[0], args[1]),
   findAllByShadowTestId: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findAllByShadowTestId(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findAllByShadowTestId(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
   findByShadowTestId: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findByShadowTestId(document.documentElement, args[0], args[1], args[2]),
+    shadowQueries.findByShadowTestId(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2]
+    ),
 };
 
-export { shadowScreen }
+export { shadowScreen };

--- a/src/trick-dom-testing-library.ts
+++ b/src/trick-dom-testing-library.ts
@@ -1,8 +1,8 @@
 declare global {
-	interface ShadowRoot {
-		matches?: (this: ShadowRoot, string: string) => boolean
-		outerHTML?: string
-	}
+  interface ShadowRoot {
+    matches?: (this: ShadowRoot, string: string) => boolean;
+    outerHTML?: string;
+  }
 }
 
 // Amazingly fun hack to trick DOM testing libraries internal type checking logic.
@@ -12,30 +12,28 @@ export function trickDOMTestingLibrary() {
   if (typeof ShadowRoot == "undefined")
     throw "Your environment does not support shadow roots.";
 
+  if (ShadowRoot.prototype.matches == null) {
+    Object.defineProperties(ShadowRoot.prototype, {
+      matches: {
+        get() {
+          return function (this: ShadowRoot, string: string): boolean {
+            const str = string.trim();
+            if (str === "*") return true;
 
-	if (ShadowRoot.prototype.matches == null) {
-  	Object.defineProperties(ShadowRoot.prototype, {
-    	matches: {
-      	get() {
-        	return function (this: ShadowRoot, string: string): boolean {
-          	const str = string.trim();
-          	if (str === "*") return true;
-
-          	return this.querySelector(string) != null ? true : false;
-        	};
-      	},
-    	},
-  	});
+            return this.querySelector(string) != null ? true : false;
+          };
+        },
+      },
+    });
   }
 
-	if (ShadowRoot.prototype.outerHTML == null) {
-  	Object.defineProperties(ShadowRoot.prototype, {
-    	outerHTML: {
-      	get() {
-        	return this.innerHTML;
-      	},
-    	},
-  	});
+  if (ShadowRoot.prototype.outerHTML == null) {
+    Object.defineProperties(ShadowRoot.prototype, {
+      outerHTML: {
+        get() {
+          return this.innerHTML;
+        },
+      },
+    });
   }
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-import { ByRoleOptions, MatcherOptions, SelectorMatcherOptions, ByRoleMatcher, Matcher, waitForOptions } from "@testing-library/dom"
+import {
+  ByRoleOptions,
+  MatcherOptions,
+  SelectorMatcherOptions,
+  ByRoleMatcher,
+  Matcher,
+  waitForOptions,
+} from "@testing-library/dom";
 
 export type Container = HTMLElement | Document | ShadowRoot;
 
@@ -68,4 +75,3 @@ export type AsyncScreenShadowMatcherParams = [
   options?: ShadowMatcherOptions | undefined,
   waitForOptions?: waitForOptions | undefined
 ];
-


### PR DESCRIPTION
TLDR: when calling: `within(element).findByShadowRole("option")` the `element` never got pushed onto the stack of elements to check.