### PR TITLE
feat: replace DOMParser with a proper printer

### DIFF
--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -18,8 +18,6 @@ test("Should strip style and script tags", () => {
 
   const str = prettyDOM(div) as string;
 
-  // console.log(str)
-
   expect(str.includes("Comment")).toBe(false);
   expect(str.includes("style")).toBe(false);
   expect(str.includes("script")).toBe(false);
@@ -34,12 +32,21 @@ test("Should test shadow roots of passing in element", async () => {
   // @ts-expect-error
   let str = prettyShadowDOM(button.getRootNode().host) as string;
 
-  // console.log(str)
-
   expect(str.includes("my-button")).toBe(true);
   expect(str.includes("ShadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(false);
   expect(str.includes("div")).toBe(false);
+
+  expect(str).toMatchInlineSnapshot(`
+    "[36m<my-button>[39m
+      [36m<ShadowRoot>[39m
+        [36m<button>[39m
+          [36m<slot />[39m
+        [36m</button>[39m
+      [36m</ShadowRoot>[39m
+      [0m0[0m
+    [36m</my-button>[39m"
+  `)
 });
 
 test("Should render body if passed in", () => {
@@ -47,10 +54,24 @@ test("Should render body if passed in", () => {
 
   const str = prettyShadowDOM(document.body) as string;
 
-  // console.log(str)
   expect(str.includes("my-button")).toBe(true);
   expect(str.includes("ShadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(true);
+
+  expect(str).toMatchInlineSnapshot(`
+    "[36m<body>[39m
+      [36m<div>[39m
+        [36m<my-button>[39m
+          [36m<ShadowRoot>[39m
+            [36m<button>[39m
+              [36m<slot />[39m
+            [36m</button>[39m
+          [36m</ShadowRoot>[39m
+          [0m0[0m
+        [36m</my-button>[39m
+      [36m</div>[39m
+    [36m</body>[39m"
+  `)
 });
 
 test("Should render HTML tag if passed in", () => {
@@ -61,12 +82,86 @@ test("Should render HTML tag if passed in", () => {
   expect(str.includes("my-button")).toBe(true);
   expect(str.includes("ShadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(true);
+
+  expect(str).toMatchInlineSnapshot(`
+    "[36m<body>[39m
+      [36m<div>[39m
+        [36m<my-button>[39m
+          [36m<ShadowRoot>[39m
+            [36m<button>[39m
+              [36m<slot />[39m
+            [36m</button>[39m
+          [36m</ShadowRoot>[39m
+          [0m0[0m
+        [36m</my-button>[39m
+      [36m</div>[39m
+    [36m</body>[39m"
+  `)
 });
 
 test("It should render 3 shadow root instances", () => {
   render(<TripleShadowRoots />);
   const str = prettyShadowDOM() as string;
 
-  // console.log(str)
   expect(str.includes("ShadowRoot")).toBe(true);
+
+  expect(str).toMatchInlineSnapshot(`
+    "[36m<body>[39m
+      [36m<div>[39m
+        [36m<triple-shadow-roots>[39m
+          [36m<ShadowRoot>[39m
+            [0m
+    			[0m
+            [36m<nested-shadow-roots>[39m
+              [36m<ShadowRoot>[39m
+                [0m
+    			[0m
+                [36m<duplicate-buttons>[39m
+                  [36m<ShadowRoot>[39m
+                    [0m
+    			[0m
+                    [36m<slot[39m
+                      [33mname[39m=[32m\\"start\\"[39m
+                    [36m/>[39m
+                    [0m
+    			[0m
+                    [36m<button>[39m
+                      [0mButton One[0m
+                    [36m</button>[39m
+                    [0m
+    			[0m
+                    [36m<br />[39m
+                    [0m
+    			[0m
+                    [36m<slot />[39m
+                    [0m
+    			[0m
+                    [36m<br />[39m
+                    [0m
+    			[0m
+                    [36m<button>[39m
+                      [0mButton Two[0m
+                    [36m</button>[39m
+                    [0m
+    			[0m
+                    [36m<slot[39m
+                      [33mname[39m=[32m\\"end\\"[39m
+                    [36m/>[39m
+                    [0m
+    		[0m
+                  [36m</ShadowRoot>[39m
+                [36m</duplicate-buttons>[39m
+                [0m
+    		[0m
+              [36m</ShadowRoot>[39m
+              [0m
+    			[0m
+            [36m</nested-shadow-roots>[39m
+            [0m
+    		[0m
+          [36m</ShadowRoot>[39m
+        [36m</triple-shadow-roots>[39m
+      [36m</div>[39m
+    [36m</body>[39m"
+  `)
 });

--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -1,7 +1,20 @@
 import * as React from "react";
 import { prettyDOM, render } from "@testing-library/react";
-import { Button, TripleShadowRoots } from "../components";
+import { Button, Duplicates, TripleShadowRoots } from "../components";
 import { prettyShadowDOM, screen } from "../src/index";
+
+/* @see https://github.com/KonnorRogers/shadow-dom-testing-library/issues/33#issuecomment-1306593757 */
+test("Should not modify the original dom", () => {
+  render(<Duplicates />);
+  const originalHTML = document.body.innerHTML;
+  expect(document.querySelector("shadow-root")).toBe(null);
+
+  prettyShadowDOM(document.body);
+
+  expect(document.querySelector("shadow-root")).toBe(null);
+  expect(originalHTML).toEqual(document.body.innerHTML);
+});
+
 
 test("Should strip style and script tags", () => {
   const div = document.createElement("div");

--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -18,6 +18,8 @@ test("Should strip style and script tags", () => {
 
   const str = prettyDOM(div) as string;
 
+  // console.log(str)
+
   expect(str.includes("Comment")).toBe(false);
   expect(str.includes("style")).toBe(false);
   expect(str.includes("script")).toBe(false);
@@ -32,6 +34,7 @@ test("Should test shadow roots of passing in element", async () => {
   // @ts-expect-error
   let str = prettyShadowDOM(button.getRootNode().host) as string;
 
+  // console.log(str)
 
   expect(str.includes("my-button")).toBe(true);
   expect(str.includes("ShadowRoot")).toBe(true);
@@ -50,22 +53,20 @@ test("Should render body if passed in", () => {
   expect(str.includes("body")).toBe(true);
 });
 
-// test("Should render HTML tag if passed in", () => {
-//   render(<Button />);
+test("Should render HTML tag if passed in", () => {
+  render(<Button />);
 
-//   const str = prettyShadowDOM() as string;
+  const str = prettyShadowDOM() as string;
 
-//   console.log(str)
-//   expect(str.includes("my-button")).toBe(true);
-//   expect(str.includes("#shadowRoot")).toBe(true);
-//   expect(str.includes("body")).toBe(true);
-// });
+  expect(str.includes("my-button")).toBe(true);
+  expect(str.includes("ShadowRoot")).toBe(true);
+  expect(str.includes("body")).toBe(true);
+});
 
 test("It should render 3 shadow root instances", () => {
 	render(<TripleShadowRoots />)
   const str = prettyShadowDOM() as string
 
-  console.log(str)
-
-  expect(str.includes("#shadowRoot")).toBe(true);
+  // console.log(str)
+  expect(str.includes("ShadowRoot")).toBe(true);
 })

--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -6,15 +6,15 @@ import { prettyShadowDOM, screen } from "../src/index";
 test("Should strip style and script tags", () => {
   const div = document.createElement("div");
 
-  const comment = document.createComment("Comment")
-  const style = document.createElement("style")
-  style.innerHTML = `style {}`
-  const script = document.createElement("script")
-  script.innerHTML = `const script = null`
-  const otherDiv = document.createElement("div")
-  otherDiv.innerHTML = "Hi"
+  const comment = document.createComment("Comment");
+  const style = document.createElement("style");
+  style.innerHTML = `style {}`;
+  const script = document.createElement("script");
+  script.innerHTML = `const script = null`;
+  const otherDiv = document.createElement("div");
+  otherDiv.innerHTML = "Hi";
 
-  div.append(comment, style, script, otherDiv)
+  div.append(comment, style, script, otherDiv);
 
   const str = prettyDOM(div) as string;
 
@@ -47,7 +47,7 @@ test("Should render body if passed in", () => {
 
   const str = prettyShadowDOM(document.body) as string;
 
-	// console.log(str)
+  // console.log(str)
   expect(str.includes("my-button")).toBe(true);
   expect(str.includes("ShadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(true);
@@ -64,9 +64,9 @@ test("Should render HTML tag if passed in", () => {
 });
 
 test("It should render 3 shadow root instances", () => {
-	render(<TripleShadowRoots />)
-  const str = prettyShadowDOM() as string
+  render(<TripleShadowRoots />);
+  const str = prettyShadowDOM() as string;
 
   // console.log(str)
   expect(str.includes("ShadowRoot")).toBe(true);
-})
+});

--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -1,17 +1,22 @@
 import * as React from "react";
-import { render } from "@testing-library/react";
+import { prettyDOM, render } from "@testing-library/react";
 import { Button, TripleShadowRoots } from "../components";
 import { prettyShadowDOM, screen } from "../src/index";
 
 test("Should strip style and script tags", () => {
   const div = document.createElement("div");
-  div.innerHTML = `
-		<!-- Comment -->
-		<style>style {}</style>
-		<script>const script = null</script>
-		<div>Hi</div>
-	`;
-  const str = prettyShadowDOM(div) as string;
+
+  const comment = document.createComment("Comment")
+  const style = document.createElement("style")
+  style.innerHTML = `style {}`
+  const script = document.createElement("script")
+  script.innerHTML = `const script = null`
+  const otherDiv = document.createElement("div")
+  otherDiv.innerHTML = "Hi"
+
+  div.append(comment, style, script, otherDiv)
+
+  const str = prettyDOM(div) as string;
 
   expect(str.includes("Comment")).toBe(false);
   expect(str.includes("style")).toBe(false);
@@ -25,10 +30,11 @@ test("Should test shadow roots of passing in element", async () => {
   const button = await screen.findByShadowRole("button");
 
   // @ts-expect-error
-  const str = prettyShadowDOM(button.getRootNode().host) as string;
+  let str = prettyShadowDOM(button.getRootNode().host) as string;
+
 
   expect(str.includes("my-button")).toBe(true);
-  expect(str.includes("#shadowRoot")).toBe(true);
+  expect(str.includes("ShadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(false);
   expect(str.includes("div")).toBe(false);
 });
@@ -38,22 +44,22 @@ test("Should render body if passed in", () => {
 
   const str = prettyShadowDOM(document.body) as string;
 
-	console.log(str)
+	// console.log(str)
   expect(str.includes("my-button")).toBe(true);
-  expect(str.includes("#shadowRoot")).toBe(true);
+  expect(str.includes("ShadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(true);
 });
 
-test("Should render HTML tag if passed in", () => {
-  render(<Button />);
+// test("Should render HTML tag if passed in", () => {
+//   render(<Button />);
 
-  const str = prettyShadowDOM() as string;
+//   const str = prettyShadowDOM() as string;
 
-  console.log(str)
-  expect(str.includes("my-button")).toBe(true);
-  expect(str.includes("#shadowRoot")).toBe(true);
-  expect(str.includes("body")).toBe(true);
-});
+//   console.log(str)
+//   expect(str.includes("my-button")).toBe(true);
+//   expect(str.includes("#shadowRoot")).toBe(true);
+//   expect(str.includes("body")).toBe(true);
+// });
 
 test("It should render 3 shadow root instances", () => {
 	render(<TripleShadowRoots />)

--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { render } from "@testing-library/react";
-import { Button, NestedShadowRoots } from "../components";
+import { Button, TripleShadowRoots } from "../components";
 import { prettyShadowDOM, screen } from "../src/index";
 
 test("Should strip style and script tags", () => {
@@ -28,7 +28,7 @@ test("Should test shadow roots of passing in element", async () => {
   const str = prettyShadowDOM(button.getRootNode().host) as string;
 
   expect(str.includes("my-button")).toBe(true);
-  expect(str.includes("shadow-root")).toBe(true);
+  expect(str.includes("#shadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(false);
   expect(str.includes("div")).toBe(false);
 });
@@ -38,8 +38,9 @@ test("Should render body if passed in", () => {
 
   const str = prettyShadowDOM(document.body) as string;
 
+	console.log(str)
   expect(str.includes("my-button")).toBe(true);
-  expect(str.includes("shadow-root")).toBe(true);
+  expect(str.includes("#shadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(true);
 });
 
@@ -48,7 +49,17 @@ test("Should render HTML tag if passed in", () => {
 
   const str = prettyShadowDOM() as string;
 
+  console.log(str)
   expect(str.includes("my-button")).toBe(true);
-  expect(str.includes("shadow-root")).toBe(true);
+  expect(str.includes("#shadowRoot")).toBe(true);
   expect(str.includes("body")).toBe(true);
 });
+
+test("It should render 3 shadow root instances", () => {
+	render(<TripleShadowRoots />)
+  const str = prettyShadowDOM() as string
+
+  console.log(str)
+
+  expect(str.includes("#shadowRoot")).toBe(true);
+})

--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -15,7 +15,6 @@ test("Should not modify the original dom", () => {
   expect(originalHTML).toEqual(document.body.innerHTML);
 });
 
-
 test("Should strip style and script tags", () => {
   const div = document.createElement("div");
 
@@ -59,7 +58,7 @@ test("Should test shadow roots of passing in element", async () => {
       [36m</ShadowRoot>[39m
       [0m0[0m
     [36m</my-button>[39m"
-  `)
+  `);
 });
 
 test("Should render body if passed in", () => {
@@ -84,7 +83,7 @@ test("Should render body if passed in", () => {
         [36m</my-button>[39m
       [36m</div>[39m
     [36m</body>[39m"
-  `)
+  `);
 });
 
 test("Should render HTML tag if passed in", () => {
@@ -109,7 +108,7 @@ test("Should render HTML tag if passed in", () => {
         [36m</my-button>[39m
       [36m</div>[39m
     [36m</body>[39m"
-  `)
+  `);
 });
 
 test("It should render 3 shadow root instances", () => {
@@ -176,5 +175,5 @@ test("It should render 3 shadow root instances", () => {
         [36m</triple-shadow-roots>[39m
       [36m</div>[39m
     [36m</body>[39m"
-  `)
+  `);
 });

--- a/__tests__/screenDebug.test.tsx
+++ b/__tests__/screenDebug.test.tsx
@@ -8,12 +8,12 @@ import {
 import { prettyShadowDOM, screen } from "../src/index";
 
 beforeEach(() => {
-  // jest.spyOn(console, 'log').mockImplementation(() => {})
+  jest.spyOn(console, 'log').mockImplementation(() => {})
 });
 
 afterEach(() => {
-  // // @ts-expect-error
-  // console.log.mockRestore()
+  // @ts-expect-error
+  console.log.mockRestore()
 });
 
 /* @see https://github.com/KonnorRogers/shadow-dom-testing-library/issues/33#issuecomment-1306593757 */
@@ -28,19 +28,148 @@ test("Should not modify the original dom", () => {
   expect(originalHTML).toEqual(document.body.innerHTML);
 });
 
-test.skip("Triple shadow roots", async () => {
+test("Triple shadow roots", async () => {
   render(<TripleShadowRoots />);
 
   screen.debug();
+  expect(console.log).toHaveBeenCalledTimes(1)
+
+  // @ts-expect-error
+  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
+    "[36m<body>[39m
+      [36m<div>[39m
+        [36m<triple-shadow-roots>[39m
+          [36m<ShadowRoot>[39m
+            [0m
+    			[0m
+            [36m<nested-shadow-roots>[39m
+              [36m<ShadowRoot>[39m
+                [0m
+    			[0m
+                [36m<duplicate-buttons>[39m
+                  [36m<ShadowRoot>[39m
+                    [0m
+    			[0m
+                    [36m<slot[39m
+                      [33mname[39m=[32m\\"start\\"[39m
+                    [36m/>[39m
+                    [0m
+    			[0m
+                    [36m<button>[39m
+                      [0mButton One[0m
+                    [36m</button>[39m
+                    [0m
+    			[0m
+                    [36m<br />[39m
+                    [0m
+    			[0m
+                    [36m<slot />[39m
+                    [0m
+    			[0m
+                    [36m<br />[39m
+                    [0m
+    			[0m
+                    [36m<button>[39m
+                      [0mButton Two[0m
+                    [36m</button>[39m
+                    [0m
+    			[0m
+                    [36m<slot[39m
+                      [33mname[39m=[32m\\"end\\"[39m
+                    [36m/>[39m
+                    [0m
+    		[0m
+                  [36m</ShadowRoot>[39m
+                [36m</duplicate-buttons>[39m
+                [0m
+    		[0m
+              [36m</ShadowRoot>[39m
+              [0m
+    			[0m
+            [36m</nested-shadow-roots>[39m
+            [0m
+    		[0m
+          [36m</ShadowRoot>[39m
+        [36m</triple-shadow-roots>[39m
+      [36m</div>[39m
+    [36m</body>[39m
+
+    [2m/Users/konnorrogers/projects/oss/shadow-dom-testing-library/src/log-shadow-dom.ts:15:25[22m
+      13 |
+      14 |   if (options == null) options = {}
+    > 15 |
+         | ^
+    "
+  `)
 });
 
-test.skip("Double shadow root", async () => {
+test("Double shadow root", async () => {
   render(<NestedShadowRoots />);
 
   screen.debug();
+
+  expect(console.log).toHaveBeenCalledTimes(1)
+
+  // @ts-expect-error
+  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
+    "[36m<body>[39m
+      [36m<div>[39m
+        [36m<nested-shadow-roots>[39m
+          [36m<ShadowRoot>[39m
+            [0m
+    			[0m
+            [36m<duplicate-buttons>[39m
+              [36m<ShadowRoot>[39m
+                [0m
+    			[0m
+                [36m<slot[39m
+                  [33mname[39m=[32m\\"start\\"[39m
+                [36m/>[39m
+                [0m
+    			[0m
+                [36m<button>[39m
+                  [0mButton One[0m
+                [36m</button>[39m
+                [0m
+    			[0m
+                [36m<br />[39m
+                [0m
+    			[0m
+                [36m<slot />[39m
+                [0m
+    			[0m
+                [36m<br />[39m
+                [0m
+    			[0m
+                [36m<button>[39m
+                  [0mButton Two[0m
+                [36m</button>[39m
+                [0m
+    			[0m
+                [36m<slot[39m
+                  [33mname[39m=[32m\\"end\\"[39m
+                [36m/>[39m
+                [0m
+    		[0m
+              [36m</ShadowRoot>[39m
+            [36m</duplicate-buttons>[39m
+            [0m
+    		[0m
+          [36m</ShadowRoot>[39m
+        [36m</nested-shadow-roots>[39m
+      [36m</div>[39m
+    [36m</body>[39m
+
+    [2m/Users/konnorrogers/projects/oss/shadow-dom-testing-library/src/log-shadow-dom.ts:15:25[22m
+      13 |
+      14 |   if (options == null) options = {}
+    > 15 |
+         | ^
+    "
+  `)
 });
 
-test.skip("Single shadow root", async () => {
+test("Single shadow root", async () => {
   render(
     <Duplicates>
       <div slot="start">Start Slot</div>
@@ -49,50 +178,70 @@ test.skip("Single shadow root", async () => {
     </Duplicates>
   );
 
-  // jest.spyOn(console, 'log').mockImplementation(() => { })
-
   screen.debug();
 
-  // @TODO: this is supposed to work but doesnt...
-  // https://github.com/testing-library/dom-testing-library/blob/edffb7c5ec2e4afd7f6bedf842c669ddbfb73297/src/__tests__/pretty-dom.js#L61
-  //   expect(console.log).toHaveBeenCalledTimes(1)
-  // 	expect(console.log.mock.calls[0][0]).toEqual(`
-  // <body>
-  // 	<div>
-  //   	<duplicate-buttons>
-  //     	<shadow-root>
-  //       	<slot
-  //         	name="start"
-  //       	/>
-  //       	<button>
-  //         	Button One
-  //       	</button>
-  //       	<br />
-  //       	<slot />
-  //       	<br />
-  //       	<button>
-  //         	Button Two
-  //       	</button>
-  //       	<slot
-  //         	name="end"
-  //       	/>
-  //     	</shadow-root>
-  //     	<div
-  //       	slot="start"
-  //     	>
-  //       	Start Slot
-  //     	</div>
-  //     	<div>
-  //       	Default Slot
-  //     	</div>
-  //     	<div
-  //       	slot="end"
-  //     	>
-  //       	End Slot
-  //     	</div>
-  //   	</duplicate-buttons>
-  // 	</div>
-  // </body>
-  //  `)
-  // 	jest.resetAllMocks()
+  expect(console.log).toHaveBeenCalledTimes(1)
+
+  // @ts-expect-error
+  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
+    "[36m<body>[39m
+      [36m<div>[39m
+        [36m<duplicate-buttons>[39m
+          [36m<ShadowRoot>[39m
+            [0m
+    			[0m
+            [36m<slot[39m
+              [33mname[39m=[32m\\"start\\"[39m
+            [36m/>[39m
+            [0m
+    			[0m
+            [36m<button>[39m
+              [0mButton One[0m
+            [36m</button>[39m
+            [0m
+    			[0m
+            [36m<br />[39m
+            [0m
+    			[0m
+            [36m<slot />[39m
+            [0m
+    			[0m
+            [36m<br />[39m
+            [0m
+    			[0m
+            [36m<button>[39m
+              [0mButton Two[0m
+            [36m</button>[39m
+            [0m
+    			[0m
+            [36m<slot[39m
+              [33mname[39m=[32m\\"end\\"[39m
+            [36m/>[39m
+            [0m
+    		[0m
+          [36m</ShadowRoot>[39m
+          [36m<div[39m
+            [33mslot[39m=[32m\\"start\\"[39m
+          [36m>[39m
+            [0mStart Slot[0m
+          [36m</div>[39m
+          [36m<div>[39m
+            [0mDefault Slot[0m
+          [36m</div>[39m
+          [36m<div[39m
+            [33mslot[39m=[32m\\"end\\"[39m
+          [36m>[39m
+            [0mEnd Slot[0m
+          [36m</div>[39m
+        [36m</duplicate-buttons>[39m
+      [36m</div>[39m
+    [36m</body>[39m
+
+    [2m/Users/konnorrogers/projects/oss/shadow-dom-testing-library/src/log-shadow-dom.ts:15:25[22m
+      13 |
+      14 |   if (options == null) options = {}
+    > 15 |
+         | ^
+    "
+  `)
 });

--- a/__tests__/screenDebug.test.tsx
+++ b/__tests__/screenDebug.test.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { getUserCodeFrame } from "@testing-library/dom/dist/get-user-code-frame"
 import { render } from "@testing-library/react";
 import {
   Duplicates,
@@ -8,18 +7,9 @@ import {
 } from "../components";
 import { screen } from "../src/index";
 
-
 beforeEach(() => {
   jest.spyOn(console, 'log').mockImplementation(() => {})
-  jest.mocked(getUserCodeFrame).mockImplementation(
-      () => `"/home/konnor/projects/sample-error/error-example.js:7:14
-        5 |         document.createTextNode('Hello World!')
-        6 |       )
-      > 7 |       screen.debug()
-          |              ^
-      "
-    `
-  )
+  jest.spyOn(screen, 'debug')
 });
 
 afterEach(() => {
@@ -32,20 +22,6 @@ test("Triple shadow roots", async () => {
 
   screen.debug();
   expect(console.log).toHaveBeenCalledTimes(1)
-
-  // @ts-expect-error
-  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot()
-});
-
-test("Double shadow root", async () => {
-  render(<NestedShadowRoots />);
-
-  screen.debug();
-
-  expect(console.log).toHaveBeenCalledTimes(1)
-
-  // @ts-expect-error
-  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot()
 });
 
 test("Single shadow root", async () => {
@@ -61,6 +37,7 @@ test("Single shadow root", async () => {
 
   expect(console.log).toHaveBeenCalledTimes(1)
 
+	// This is kind of a silly testing, but its more about making sure we properly loaded our plugin.
   // @ts-expect-error
-  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot()
+  expect(console.log.mock.calls[0][0]).toMatch(/ShadowRoot/)
 });

--- a/__tests__/screenDebug.test.tsx
+++ b/__tests__/screenDebug.test.tsx
@@ -1,31 +1,30 @@
 import React from "react";
+import { getUserCodeFrame } from "@testing-library/dom/dist/get-user-code-frame"
 import { render } from "@testing-library/react";
 import {
   Duplicates,
   NestedShadowRoots,
   TripleShadowRoots,
 } from "../components";
-import { prettyShadowDOM, screen } from "../src/index";
+import { screen } from "../src/index";
+
 
 beforeEach(() => {
   jest.spyOn(console, 'log').mockImplementation(() => {})
+  jest.mocked(getUserCodeFrame).mockImplementation(
+      () => `"/home/konnor/projects/sample-error/error-example.js:7:14
+        5 |         document.createTextNode('Hello World!')
+        6 |       )
+      > 7 |       screen.debug()
+          |              ^
+      "
+    `
+  )
 });
 
 afterEach(() => {
   // @ts-expect-error
   console.log.mockRestore()
-});
-
-/* @see https://github.com/KonnorRogers/shadow-dom-testing-library/issues/33#issuecomment-1306593757 */
-test("Should not modify the original dom", () => {
-  render(<Duplicates />);
-  const originalHTML = document.body.innerHTML;
-  expect(document.querySelector("shadow-root")).toBe(null);
-
-  prettyShadowDOM(document.body);
-
-  expect(document.querySelector("shadow-root")).toBe(null);
-  expect(originalHTML).toEqual(document.body.innerHTML);
 });
 
 test("Triple shadow roots", async () => {
@@ -35,72 +34,7 @@ test("Triple shadow roots", async () => {
   expect(console.log).toHaveBeenCalledTimes(1)
 
   // @ts-expect-error
-  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
-    "[36m<body>[39m
-      [36m<div>[39m
-        [36m<triple-shadow-roots>[39m
-          [36m<ShadowRoot>[39m
-            [0m
-    			[0m
-            [36m<nested-shadow-roots>[39m
-              [36m<ShadowRoot>[39m
-                [0m
-    			[0m
-                [36m<duplicate-buttons>[39m
-                  [36m<ShadowRoot>[39m
-                    [0m
-    			[0m
-                    [36m<slot[39m
-                      [33mname[39m=[32m\\"start\\"[39m
-                    [36m/>[39m
-                    [0m
-    			[0m
-                    [36m<button>[39m
-                      [0mButton One[0m
-                    [36m</button>[39m
-                    [0m
-    			[0m
-                    [36m<br />[39m
-                    [0m
-    			[0m
-                    [36m<slot />[39m
-                    [0m
-    			[0m
-                    [36m<br />[39m
-                    [0m
-    			[0m
-                    [36m<button>[39m
-                      [0mButton Two[0m
-                    [36m</button>[39m
-                    [0m
-    			[0m
-                    [36m<slot[39m
-                      [33mname[39m=[32m\\"end\\"[39m
-                    [36m/>[39m
-                    [0m
-    		[0m
-                  [36m</ShadowRoot>[39m
-                [36m</duplicate-buttons>[39m
-                [0m
-    		[0m
-              [36m</ShadowRoot>[39m
-              [0m
-    			[0m
-            [36m</nested-shadow-roots>[39m
-            [0m
-    		[0m
-          [36m</ShadowRoot>[39m
-        [36m</triple-shadow-roots>[39m
-      [36m</div>[39m
-    [36m</body>[39m
-
-    [2m/Users/konnorrogers/projects/oss/shadow-dom-testing-library/src/log-shadow-dom.ts:15:25[22m
-      13 |
-      14 |   if (options == null) options = {}
-    > 15 |
-         | ^
-    "
-  `)
+  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot()
 });
 
 test("Double shadow root", async () => {
@@ -111,62 +45,7 @@ test("Double shadow root", async () => {
   expect(console.log).toHaveBeenCalledTimes(1)
 
   // @ts-expect-error
-  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
-    "[36m<body>[39m
-      [36m<div>[39m
-        [36m<nested-shadow-roots>[39m
-          [36m<ShadowRoot>[39m
-            [0m
-    			[0m
-            [36m<duplicate-buttons>[39m
-              [36m<ShadowRoot>[39m
-                [0m
-    			[0m
-                [36m<slot[39m
-                  [33mname[39m=[32m\\"start\\"[39m
-                [36m/>[39m
-                [0m
-    			[0m
-                [36m<button>[39m
-                  [0mButton One[0m
-                [36m</button>[39m
-                [0m
-    			[0m
-                [36m<br />[39m
-                [0m
-    			[0m
-                [36m<slot />[39m
-                [0m
-    			[0m
-                [36m<br />[39m
-                [0m
-    			[0m
-                [36m<button>[39m
-                  [0mButton Two[0m
-                [36m</button>[39m
-                [0m
-    			[0m
-                [36m<slot[39m
-                  [33mname[39m=[32m\\"end\\"[39m
-                [36m/>[39m
-                [0m
-    		[0m
-              [36m</ShadowRoot>[39m
-            [36m</duplicate-buttons>[39m
-            [0m
-    		[0m
-          [36m</ShadowRoot>[39m
-        [36m</nested-shadow-roots>[39m
-      [36m</div>[39m
-    [36m</body>[39m
-
-    [2m/Users/konnorrogers/projects/oss/shadow-dom-testing-library/src/log-shadow-dom.ts:15:25[22m
-      13 |
-      14 |   if (options == null) options = {}
-    > 15 |
-         | ^
-    "
-  `)
+  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot()
 });
 
 test("Single shadow root", async () => {
@@ -183,65 +62,5 @@ test("Single shadow root", async () => {
   expect(console.log).toHaveBeenCalledTimes(1)
 
   // @ts-expect-error
-  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
-    "[36m<body>[39m
-      [36m<div>[39m
-        [36m<duplicate-buttons>[39m
-          [36m<ShadowRoot>[39m
-            [0m
-    			[0m
-            [36m<slot[39m
-              [33mname[39m=[32m\\"start\\"[39m
-            [36m/>[39m
-            [0m
-    			[0m
-            [36m<button>[39m
-              [0mButton One[0m
-            [36m</button>[39m
-            [0m
-    			[0m
-            [36m<br />[39m
-            [0m
-    			[0m
-            [36m<slot />[39m
-            [0m
-    			[0m
-            [36m<br />[39m
-            [0m
-    			[0m
-            [36m<button>[39m
-              [0mButton Two[0m
-            [36m</button>[39m
-            [0m
-    			[0m
-            [36m<slot[39m
-              [33mname[39m=[32m\\"end\\"[39m
-            [36m/>[39m
-            [0m
-    		[0m
-          [36m</ShadowRoot>[39m
-          [36m<div[39m
-            [33mslot[39m=[32m\\"start\\"[39m
-          [36m>[39m
-            [0mStart Slot[0m
-          [36m</div>[39m
-          [36m<div>[39m
-            [0mDefault Slot[0m
-          [36m</div>[39m
-          [36m<div[39m
-            [33mslot[39m=[32m\\"end\\"[39m
-          [36m>[39m
-            [0mEnd Slot[0m
-          [36m</div>[39m
-        [36m</duplicate-buttons>[39m
-      [36m</div>[39m
-    [36m</body>[39m
-
-    [2m/Users/konnorrogers/projects/oss/shadow-dom-testing-library/src/log-shadow-dom.ts:15:25[22m
-      13 |
-      14 |   if (options == null) options = {}
-    > 15 |
-         | ^
-    "
-  `)
+  expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot()
 });

--- a/__tests__/screenDebug.test.tsx
+++ b/__tests__/screenDebug.test.tsx
@@ -8,20 +8,20 @@ import {
 import { screen } from "../src/index";
 
 beforeEach(() => {
-  jest.spyOn(console, 'log').mockImplementation(() => {})
-  jest.spyOn(screen, 'debug')
+  jest.spyOn(console, "log").mockImplementation(() => {});
+  jest.spyOn(screen, "debug");
 });
 
 afterEach(() => {
   // @ts-expect-error
-  console.log.mockRestore()
+  console.log.mockRestore();
 });
 
 test("Triple shadow roots", async () => {
   render(<TripleShadowRoots />);
 
   screen.debug();
-  expect(console.log).toHaveBeenCalledTimes(1)
+  expect(console.log).toHaveBeenCalledTimes(1);
 });
 
 test("Single shadow root", async () => {
@@ -35,9 +35,9 @@ test("Single shadow root", async () => {
 
   screen.debug();
 
-  expect(console.log).toHaveBeenCalledTimes(1)
+  expect(console.log).toHaveBeenCalledTimes(1);
 
-	// This is kind of a silly testing, but its more about making sure we properly loaded our plugin.
+  // This is kind of a silly testing, but its more about making sure we properly loaded our plugin.
   // @ts-expect-error
-  expect(console.log.mock.calls[0][0]).toMatch(/ShadowRoot/)
+  expect(console.log.mock.calls[0][0]).toMatch(/ShadowRoot/);
 });

--- a/src/log-shadow-dom.ts
+++ b/src/log-shadow-dom.ts
@@ -10,6 +10,7 @@ export function logShadowDOM(
   const plugin: NewPlugin = createDOMElementFilter(
     options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
   );
+
   if (options == null) options = {}
   if (options.plugins == null) options.plugins = []
   options.plugins.push(plugin)

--- a/src/log-shadow-dom.ts
+++ b/src/log-shadow-dom.ts
@@ -10,11 +10,8 @@ export function logShadowDOM(
   const plugin: NewPlugin = createDOMElementFilter(
     options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
   );
-
   if (options == null) options = {}
-
   if (options.plugins == null) options.plugins = []
-
   options.plugins.push(plugin)
 
   logDOM(dom, maxLength, options);

--- a/src/log-shadow-dom.ts
+++ b/src/log-shadow-dom.ts
@@ -1,5 +1,8 @@
 import { logDOM } from "@testing-library/dom";
-import { createDOMElementFilter, filterCommentsAndDefaultIgnoreTagsTags } from "./pretty-shadow-dom";
+import {
+  createDOMElementFilter,
+  filterCommentsAndDefaultIgnoreTagsTags,
+} from "./pretty-shadow-dom";
 import type { NewPlugin } from "pretty-format";
 
 export function logShadowDOM(
@@ -11,9 +14,9 @@ export function logShadowDOM(
     options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
   );
 
-  if (options == null) options = {}
-  if (options.plugins == null) options.plugins = []
-  options.plugins.push(plugin)
+  if (options == null) options = {};
+  if (options.plugins == null) options.plugins = [];
+  options.plugins.push(plugin);
 
   logDOM(dom, maxLength, options);
 }

--- a/src/log-shadow-dom.ts
+++ b/src/log-shadow-dom.ts
@@ -1,9 +1,21 @@
 import { logDOM } from "@testing-library/dom";
+import { createDOMElementFilter, filterCommentsAndDefaultIgnoreTagsTags } from "./pretty-shadow-dom";
+import type { NewPlugin } from "pretty-format";
 
 export function logShadowDOM(
   ...args: Parameters<typeof logDOM>
 ): ReturnType<typeof logDOM> {
-  const [dom, maxLength, options] = args;
+  let [dom, maxLength, options] = args;
+
+  const plugin: NewPlugin = createDOMElementFilter(
+    options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
+  );
+
+  if (options == null) options = {}
+
+  if (options.plugins == null) options.plugins = []
+
+  options.plugins.push(plugin)
 
   logDOM(dom, maxLength, options);
 }

--- a/src/log-shadow-dom.ts
+++ b/src/log-shadow-dom.ts
@@ -1,10 +1,9 @@
 import { logDOM } from "@testing-library/dom";
-import { toJSDOM } from "./pretty-shadow-dom";
 
 export function logShadowDOM(
   ...args: Parameters<typeof logDOM>
 ): ReturnType<typeof logDOM> {
   const [dom, maxLength, options] = args;
 
-  logDOM(toJSDOM(dom), maxLength, options);
+  logDOM(dom, maxLength, options);
 }

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -1,62 +1,69 @@
-/**
- * This is an extension of prettyDOM / logDOM that provides proper printing of shadow roots.
- * Pulled from here: https://github.com/AriPerkkio/aria-live-capture/blob/85f1e4613bec443797097320ed5f2b9f733fc729/.storybook/pretty-dom-with-shadow-dom.ts
- */
-import { prettyDOM } from "@testing-library/dom";
-import type { Config, NewPlugin, Printer, Refs } from "pretty-format";
-import { getAllElementsAndShadowRoots } from "./deep-query-selectors";
+import { prettyDOM, getConfig } from '@testing-library/dom'
+import type {Config, NewPlugin, Printer, Refs} from 'pretty-format'
 
 export function prettyShadowDOM(
-  ...args: Parameters<typeof prettyDOM>
+    ...args: Parameters<typeof prettyDOM>
 ): ReturnType<typeof prettyDOM> {
-  const [dom, maxLength, options] = args;
+    let [dom, maxLength, options] = args;
 
-  const plugin: NewPlugin = {
-    test: (val: any) => {
-      const bool = val?.constructor && testNode(val);
-      return bool;
-    },
-    serialize,
-  };
+    const plugin: NewPlugin = createDOMElementFilter(options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags)
 
-  return prettyDOM(dom, maxLength, {
-    ...options,
-    plugins: [plugin],
-    filterNode: () => true,
-  });
+    if (options?.plugins) {
+      options.plugins.push(plugin)
+    } else {
+      if (options == null) {
+        options = {}
+      }
+
+      options.plugins = [plugin]
+    }
+
+    return prettyDOM(dom, maxLength, {
+        ...options,
+        plugins: [plugin],
+    });
 }
 
 function escapeHTML(str: string): string {
-  return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return str.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function filterCommentsAndDefaultIgnoreTagsTags(value: Node) {
+  return (
+    value.nodeType !== COMMENT_NODE &&
+    (value.nodeType !== ELEMENT_NODE ||
+      // @ts-expect-error
+      !value.matches(getConfig().defaultIgnore))
+  )
 }
 
 // Return empty string if keys is empty.
-function printProps(
+const printProps = (
   keys: Array<string>,
   props: Record<string, unknown>,
   config: Config,
   indentation: string,
   depth: number,
   refs: Refs,
-  printer: Printer
-): string {
-  const indentationNext = indentation + config.indent;
-  const colors = config.colors;
+  printer: Printer,
+): string => {
+  const indentationNext = indentation + config.indent
+  const colors = config.colors
   return keys
-    .map((key) => {
-      const value = props[key];
-      let printed = printer(value, config, indentationNext, depth, refs);
+    .map(key => {
+      const value = props[key]
+      let printed = printer(value, config, indentationNext, depth, refs)
 
-      if (typeof value !== "string") {
-        if (printed.indexOf("\n") !== -1) {
+      if (typeof value !== 'string') {
+        if (printed.indexOf('\n') !== -1) {
           printed =
             config.spacingOuter +
             indentationNext +
             printed +
             config.spacingOuter +
-            indentation;
+            indentation
         }
-        printed = "{" + printed + "}";
+        printed = '{' + printed + '}'
       }
 
       return (
@@ -65,17 +72,17 @@ function printProps(
         colors.prop.open +
         key +
         colors.prop.close +
-        "=" +
+        '=' +
         colors.value.open +
         printed +
         colors.value.close
-      );
+      )
     })
-    .join("");
+    .join('')
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#node_type_constants
-const NodeTypeTextNode = 3;
+const NodeTypeTextNode = 3
 
 // Return empty string if children is empty.
 const printChildren = (
@@ -84,43 +91,43 @@ const printChildren = (
   indentation: string,
   depth: number,
   refs: Refs,
-  printer: Printer
+  printer: Printer,
 ): string =>
   children
-    .map((child) => {
+    .map(child => {
       const printedChild =
-        typeof child === "string"
+        typeof child === 'string'
           ? printText(child, config)
-          : printer(child, config, indentation, depth, refs);
+          : printer(child, config, indentation, depth, refs)
 
       if (
-        printedChild === "" &&
-        typeof child === "object" &&
+        printedChild === '' &&
+        typeof child === 'object' &&
         child !== null &&
         (child as Node).nodeType !== NodeTypeTextNode
       ) {
         // A plugin serialized this Node to '' meaning we should ignore it.
-        return "";
+        return ''
       }
-      return config.spacingOuter + indentation + printedChild;
+      return config.spacingOuter + indentation + printedChild
     })
-    .join("");
+    .join('')
 
 const printText = (text: string, config: Config): string => {
-  const contentColor = config.colors.content;
-  return contentColor.open + escapeHTML(text) + contentColor.close;
-};
+  const contentColor = config.colors.content
+  return contentColor.open + escapeHTML(text) + contentColor.close
+}
 
 const printComment = (comment: string, config: Config): string => {
-  const commentColor = config.colors.comment;
+  const commentColor = config.colors.comment
   return (
     commentColor.open +
-    "<!--" +
+    '<!--' +
     escapeHTML(comment) +
-    "-->" +
+    '-->' +
     commentColor.close
-  );
-};
+  )
+}
 
 // Separate the functions to format props, children, and element,
 // so a plugin could override a particular function, if needed.
@@ -130,18 +137,14 @@ const printElement = (
   type: string,
   printedProps: string,
   printedChildren: string,
-  hasShadowRoot: boolean,
   config: Config,
-  indentation: string
+  indentation: string,
 ): string => {
-  const tagColor = config.colors.tag;
-  const shadowRootMarkup = hasShadowRoot
-    ? `${config.spacingOuter + indentation}  #shadow-root`
-    : "";
+  const tagColor = config.colors.tag
 
   return (
     tagColor.open +
-    "<" +
+    '<' +
     type +
     (printedProps &&
       tagColor.close +
@@ -150,164 +153,153 @@ const printElement = (
         indentation +
         tagColor.open) +
     (printedChildren
-      ? ">" +
-        shadowRootMarkup +
+      ? '>' +
         tagColor.close +
         printedChildren +
         config.spacingOuter +
         indentation +
         tagColor.open +
-        "</" +
+        '</' +
         type
-      : (printedProps && !config.min ? "" : " ") + "/") +
-    ">" +
+      : (printedProps && !config.min ? '' : ' ') + '/') +
+    '>' +
     tagColor.close
-  );
-};
+  )
+}
 
 const printElementAsLeaf = (type: string, config: Config): string => {
-  const tagColor = config.colors.tag;
+  const tagColor = config.colors.tag
   return (
     tagColor.open +
-    "<" +
+    '<' +
     type +
     tagColor.close +
-    " …" +
+    ' …' +
     tagColor.open +
-    " />" +
+    ' />' +
     tagColor.close
-  );
-};
+  )
+}
 
-const ELEMENT_NODE = 1;
-const TEXT_NODE = 3;
-const COMMENT_NODE = 8;
-const FRAGMENT_NODE = 11;
+const ELEMENT_NODE = 1
+const TEXT_NODE = 3
+const COMMENT_NODE = 8
+const FRAGMENT_NODE = 11
 
-const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/;
+const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/
 
 const testNode = (val: any) => {
-  const constructorName = val.constructor.name;
-  const { nodeType, tagName } = val;
+  const constructorName = val?.constructor?.name || ""
+  const {nodeType, tagName} = val
   const isCustomElement =
-    (typeof tagName === "string" && tagName.includes("-")) ||
-    (typeof val.hasAttribute === "function" && val.hasAttribute("is"));
+    (typeof tagName === 'string' && tagName.includes('-')) ||
+    (typeof val.hasAttribute === 'function' && val.hasAttribute('is'))
 
   return (
     (nodeType === ELEMENT_NODE &&
       (ELEMENT_REGEXP.test(constructorName) || isCustomElement)) ||
-    (nodeType === TEXT_NODE && constructorName === "Text") ||
-    (nodeType === COMMENT_NODE && constructorName === "Comment") ||
-    (nodeType === FRAGMENT_NODE && constructorName === "DocumentFragment")
-  );
-};
+    (nodeType === TEXT_NODE && constructorName === 'Text') ||
+    (nodeType === COMMENT_NODE && constructorName === 'Comment') ||
+    (nodeType === FRAGMENT_NODE)
+  )
+}
 
-type HandledType = Element | Text | Comment | DocumentFragment;
+export const test: NewPlugin['test'] = (val: any) =>
+  val?.constructor?.name && testNode(val)
+
+type HandledType = Element | Text | Comment | DocumentFragment
 
 function nodeIsText(node: HandledType): node is Text {
-  return node.nodeType === TEXT_NODE;
+  return node.nodeType === TEXT_NODE
 }
 
 function nodeIsComment(node: HandledType): node is Comment {
-  return node.nodeType === COMMENT_NODE;
+  return node.nodeType === COMMENT_NODE
 }
 
-function nodeIsFragment(node: HandledType): node is DocumentFragment {
-  return node.nodeType === FRAGMENT_NODE;
+function nodeIsFragment(node: HandledType): node is DocumentFragment | ShadowRoot {
+  return node.nodeType === FRAGMENT_NODE
 }
 
-function serialize(
-  node: HandledType,
-  config: Config,
-  indentation: string,
-  depth: number,
-  refs: Refs,
-  printer: Printer
-): string {
-  if (nodeIsText(node)) {
-    return printText(node.data, config);
+export function createDOMElementFilter(
+  filterNode: (node: Node) => boolean,
+): NewPlugin {
+
+  function getChildren (node: Element | DocumentFragment | ShadowRoot) {
+    const children = Array.prototype.slice
+      .call(node.childNodes || node.children)
+
+    if ("shadowRoot" in node && node.shadowRoot != null && node.shadowRoot.mode !== "closed") {
+      children.unshift(node.shadowRoot)
+    }
+
+    return children.filter(filterNode)
   }
 
-  if (nodeIsComment(node)) {
-    return printComment(node.data, config);
+  return {
+    test: (val: any) => val?.constructor && testNode(val),
+    serialize: (
+      node: HandledType,
+      config: Config,
+      indentation: string,
+      depth: number,
+      refs: Refs,
+      printer: Printer,
+    ) => {
+      if (nodeIsText(node)) {
+        return printText(node.data, config)
+      }
+
+      if (nodeIsComment(node)) {
+        return printComment(node.data, config)
+      }
+
+      let type = "DocumentFragment"
+
+      if ("tagName" in node && node.tagName) {
+        type = node.tagName.toLowerCase()
+      } else if (node instanceof ShadowRoot) {
+        type = "ShadowRoot"
+      }
+
+      if (++depth > config.maxDepth) {
+        return printElementAsLeaf(type, config)
+      }
+
+      return printElement(
+        type,
+        printProps(
+          nodeIsFragment(node)
+            ? []
+            : Array.from(node.attributes)
+                .map(attr => attr.name)
+                .sort(),
+          nodeIsFragment(node)
+            ? {}
+            : Array.from(node.attributes).reduce<Record<string, string>>(
+                (props, attribute) => {
+                  props[attribute.name] = attribute.value
+                  return props
+                },
+                {},
+              ),
+          config,
+          indentation + config.indent,
+          depth,
+          refs,
+          printer,
+        ),
+        printChildren(
+          getChildren(node),
+          config,
+          indentation + config.indent,
+          depth,
+          refs,
+          printer,
+        ),
+        config,
+        indentation,
+      )
+    },
   }
-
-  const type = nodeIsFragment(node)
-    ? `DocumentFragment`
-    : node.tagName.toLowerCase();
-
-  if (++depth > config.maxDepth) {
-    return printElementAsLeaf(type, config);
-  }
-
-  const children = printChildren(
-    getChildren(node),
-    config,
-    indentation + config.indent,
-    depth,
-    refs,
-    printer
-  );
-
-  const hasShadowRoot = "shadowRoot" in node && node.shadowRoot != null;
-
-  return printElement(
-    type,
-    printProps(
-      nodeIsFragment(node)
-        ? []
-        : Array.from(node.attributes)
-            .map((attr) => attr.name)
-            .sort(),
-      nodeIsFragment(node)
-        ? {}
-        : Array.from(node.attributes).reduce<Record<string, string>>(
-            (props, attribute) => {
-              props[attribute.name] = attribute.value;
-              return props;
-            },
-            {}
-          ),
-      config,
-      indentation + config.indent,
-      depth,
-      refs,
-      printer
-    ),
-    children,
-    hasShadowRoot,
-    config,
-    indentation
-  );
-}
-
-function getChildren(node: Element | DocumentFragment, filterNode = () => true): Node[] {
-	return getAllChildNodes(node).filter(filterNode)
-}
-
-function getAllChildNodes (node: Node | ShadowRoot | Element | DocumentFragment, finalNodes: (Node | Element)[] = []): Node[] {
-	const nodes = getChildNodes(node)
-
-	nodes.forEach((childNode) => {
-		if (node == null) return
-
-		finalNodes.push(childNode)
-
-		if ("shadowRoot" in childNode && childNode.shadowRoot != null && childNode.shadowRoot.mode === "open") {
-			getAllChildNodes(childNode.shadowRoot, finalNodes)
-		}
-
-		getAllChildNodes(childNode, finalNodes)
-	})
-
-
-	return finalNodes as Node[]
-}
-
-function getChildNodes (node: Element | Node): (Node | Element)[] {
-	if ("children" in node) {
-		return Array.prototype.slice.call(node.childNodes || node.children)
-	}
-
-	return Array.prototype.slice.call(node.childNodes)
 }

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -10,8 +10,8 @@ export function prettyShadowDOM(
     options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
   );
 
-  if (options == null) options = {}
-  if (options.plugins == null) options.plugins = []
+  if (options == null) options = {};
+  if (options.plugins == null) options.plugins = [];
 
   options.plugins.push(plugin);
 

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -1,31 +1,33 @@
-import { prettyDOM, getConfig } from '@testing-library/dom'
-import type {Config, NewPlugin, Printer, Refs} from 'pretty-format'
+import { prettyDOM, getConfig } from "@testing-library/dom";
+import type { Config, NewPlugin, Printer, Refs } from "pretty-format";
 
 export function prettyShadowDOM(
-    ...args: Parameters<typeof prettyDOM>
+  ...args: Parameters<typeof prettyDOM>
 ): ReturnType<typeof prettyDOM> {
-    let [dom, maxLength, options] = args;
+  let [dom, maxLength, options] = args;
 
-    const plugin: NewPlugin = createDOMElementFilter(options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags)
+  const plugin: NewPlugin = createDOMElementFilter(
+    options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
+  );
 
-    if (options?.plugins) {
-      options.plugins.push(plugin)
-    } else {
-      if (options == null) {
-        options = {}
-      }
-
-      options.plugins = [plugin]
+  if (options?.plugins) {
+    options.plugins.push(plugin);
+  } else {
+    if (options == null) {
+      options = {};
     }
 
-    return prettyDOM(dom, maxLength, {
-        ...options,
-        plugins: [plugin],
-    });
+    options.plugins = [plugin];
+  }
+
+  return prettyDOM(dom, maxLength, {
+    ...options,
+    plugins: [plugin],
+  });
 }
 
 function escapeHTML(str: string): string {
-  return str.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 function filterCommentsAndDefaultIgnoreTagsTags(value: Node) {
@@ -34,7 +36,7 @@ function filterCommentsAndDefaultIgnoreTagsTags(value: Node) {
     (value.nodeType !== ELEMENT_NODE ||
       // @ts-expect-error
       !value.matches(getConfig().defaultIgnore))
-  )
+  );
 }
 
 // Return empty string if keys is empty.
@@ -45,25 +47,25 @@ const printProps = (
   indentation: string,
   depth: number,
   refs: Refs,
-  printer: Printer,
+  printer: Printer
 ): string => {
-  const indentationNext = indentation + config.indent
-  const colors = config.colors
+  const indentationNext = indentation + config.indent;
+  const colors = config.colors;
   return keys
-    .map(key => {
-      const value = props[key]
-      let printed = printer(value, config, indentationNext, depth, refs)
+    .map((key) => {
+      const value = props[key];
+      let printed = printer(value, config, indentationNext, depth, refs);
 
-      if (typeof value !== 'string') {
-        if (printed.indexOf('\n') !== -1) {
+      if (typeof value !== "string") {
+        if (printed.indexOf("\n") !== -1) {
           printed =
             config.spacingOuter +
             indentationNext +
             printed +
             config.spacingOuter +
-            indentation
+            indentation;
         }
-        printed = '{' + printed + '}'
+        printed = "{" + printed + "}";
       }
 
       return (
@@ -72,17 +74,17 @@ const printProps = (
         colors.prop.open +
         key +
         colors.prop.close +
-        '=' +
+        "=" +
         colors.value.open +
         printed +
         colors.value.close
-      )
+      );
     })
-    .join('')
-}
+    .join("");
+};
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#node_type_constants
-const NodeTypeTextNode = 3
+const NodeTypeTextNode = 3;
 
 // Return empty string if children is empty.
 const printChildren = (
@@ -91,43 +93,43 @@ const printChildren = (
   indentation: string,
   depth: number,
   refs: Refs,
-  printer: Printer,
+  printer: Printer
 ): string =>
   children
-    .map(child => {
+    .map((child) => {
       const printedChild =
-        typeof child === 'string'
+        typeof child === "string"
           ? printText(child, config)
-          : printer(child, config, indentation, depth, refs)
+          : printer(child, config, indentation, depth, refs);
 
       if (
-        printedChild === '' &&
-        typeof child === 'object' &&
+        printedChild === "" &&
+        typeof child === "object" &&
         child !== null &&
         (child as Node).nodeType !== NodeTypeTextNode
       ) {
         // A plugin serialized this Node to '' meaning we should ignore it.
-        return ''
+        return "";
       }
-      return config.spacingOuter + indentation + printedChild
+      return config.spacingOuter + indentation + printedChild;
     })
-    .join('')
+    .join("");
 
 const printText = (text: string, config: Config): string => {
-  const contentColor = config.colors.content
-  return contentColor.open + escapeHTML(text) + contentColor.close
-}
+  const contentColor = config.colors.content;
+  return contentColor.open + escapeHTML(text) + contentColor.close;
+};
 
 const printComment = (comment: string, config: Config): string => {
-  const commentColor = config.colors.comment
+  const commentColor = config.colors.comment;
   return (
     commentColor.open +
-    '<!--' +
+    "<!--" +
     escapeHTML(comment) +
-    '-->' +
+    "-->" +
     commentColor.close
-  )
-}
+  );
+};
 
 // Separate the functions to format props, children, and element,
 // so a plugin could override a particular function, if needed.
@@ -138,13 +140,13 @@ const printElement = (
   printedProps: string,
   printedChildren: string,
   config: Config,
-  indentation: string,
+  indentation: string
 ): string => {
-  const tagColor = config.colors.tag
+  const tagColor = config.colors.tag;
 
   return (
     tagColor.open +
-    '<' +
+    "<" +
     type +
     (printedProps &&
       tagColor.close +
@@ -153,86 +155,94 @@ const printElement = (
         indentation +
         tagColor.open) +
     (printedChildren
-      ? '>' +
+      ? ">" +
         tagColor.close +
         printedChildren +
         config.spacingOuter +
         indentation +
         tagColor.open +
-        '</' +
+        "</" +
         type
-      : (printedProps && !config.min ? '' : ' ') + '/') +
-    '>' +
+      : (printedProps && !config.min ? "" : " ") + "/") +
+    ">" +
     tagColor.close
-  )
-}
+  );
+};
 
 const printElementAsLeaf = (type: string, config: Config): string => {
-  const tagColor = config.colors.tag
+  const tagColor = config.colors.tag;
   return (
     tagColor.open +
-    '<' +
+    "<" +
     type +
     tagColor.close +
-    ' …' +
+    " …" +
     tagColor.open +
-    ' />' +
+    " />" +
     tagColor.close
-  )
-}
+  );
+};
 
-const ELEMENT_NODE = 1
-const TEXT_NODE = 3
-const COMMENT_NODE = 8
-const FRAGMENT_NODE = 11
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const COMMENT_NODE = 8;
+const FRAGMENT_NODE = 11;
 
-const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/
+const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/;
 
 const testNode = (val: any) => {
-  const constructorName = val?.constructor?.name || ""
-  const {nodeType, tagName} = val
+  const constructorName = val?.constructor?.name || "";
+  const { nodeType, tagName } = val;
   const isCustomElement =
-    (typeof tagName === 'string' && tagName.includes('-')) ||
-    (typeof val.hasAttribute === 'function' && val.hasAttribute('is'))
+    (typeof tagName === "string" && tagName.includes("-")) ||
+    (typeof val.hasAttribute === "function" && val.hasAttribute("is"));
 
   return (
     (nodeType === ELEMENT_NODE &&
       (ELEMENT_REGEXP.test(constructorName) || isCustomElement)) ||
-    (nodeType === TEXT_NODE && constructorName === 'Text') ||
-    (nodeType === COMMENT_NODE && constructorName === 'Comment') ||
-    (nodeType === FRAGMENT_NODE)
-  )
-}
+    (nodeType === TEXT_NODE && constructorName === "Text") ||
+    (nodeType === COMMENT_NODE && constructorName === "Comment") ||
+    nodeType === FRAGMENT_NODE
+  );
+};
 
-export const test: NewPlugin['test'] = (val: any) =>
-  val?.constructor?.name && testNode(val)
+export const test: NewPlugin["test"] = (val: any) =>
+  val?.constructor?.name && testNode(val);
 
-type HandledType = Element | Text | Comment | DocumentFragment
+type HandledType = Element | Text | Comment | DocumentFragment;
 
 function nodeIsText(node: HandledType): node is Text {
-  return node.nodeType === TEXT_NODE
+  return node.nodeType === TEXT_NODE;
 }
 
 function nodeIsComment(node: HandledType): node is Comment {
-  return node.nodeType === COMMENT_NODE
+  return node.nodeType === COMMENT_NODE;
 }
 
-function nodeIsFragment(node: HandledType): node is DocumentFragment | ShadowRoot {
-  return node.nodeType === FRAGMENT_NODE
+function nodeIsFragment(
+  node: HandledType
+): node is DocumentFragment | ShadowRoot {
+  return node.nodeType === FRAGMENT_NODE;
 }
 
 export function createDOMElementFilter(
-  filterNode: (node: Node) => boolean,
+  filterNode: (node: Node) => boolean
 ): NewPlugin {
+  function getChildren(
+    node: Element | DocumentFragment | ShadowRoot
+  ): (Node | Element | ShadowRoot)[] {
+    const children: (Node | Element | ShadowRoot)[] =
+      Array.prototype.slice.call(node.childNodes || node.children);
 
-  function getChildren (node: Element | DocumentFragment | ShadowRoot): (Node | Element | ShadowRoot)[] {
-    const children: (Node | Element | ShadowRoot)[] = Array.prototype.slice.call(node.childNodes || node.children)
-
-    if ("shadowRoot" in node && node.shadowRoot != null && node.shadowRoot.mode !== "closed") {
-      children.unshift(node.shadowRoot)
+    if (
+      "shadowRoot" in node &&
+      node.shadowRoot != null &&
+      node.shadowRoot.mode !== "closed"
+    ) {
+      children.unshift(node.shadowRoot);
     }
 
-    return children.filter(filterNode)
+    return children.filter(filterNode);
   }
 
   return {
@@ -243,26 +253,26 @@ export function createDOMElementFilter(
       indentation: string,
       depth: number,
       refs: Refs,
-      printer: Printer,
+      printer: Printer
     ) => {
       if (nodeIsText(node)) {
-        return printText(node.data, config)
+        return printText(node.data, config);
       }
 
       if (nodeIsComment(node)) {
-        return printComment(node.data, config)
+        return printComment(node.data, config);
       }
 
-      let type = "DocumentFragment"
+      let type = "DocumentFragment";
 
       if ("tagName" in node && node.tagName) {
-        type = node.tagName.toLowerCase()
+        type = node.tagName.toLowerCase();
       } else if (node instanceof ShadowRoot) {
-        type = "ShadowRoot"
+        type = "ShadowRoot";
       }
 
       if (++depth > config.maxDepth) {
-        return printElementAsLeaf(type, config)
+        return printElementAsLeaf(type, config);
       }
 
       return printElement(
@@ -271,22 +281,22 @@ export function createDOMElementFilter(
           nodeIsFragment(node)
             ? []
             : Array.from(node.attributes)
-                .map(attr => attr.name)
+                .map((attr) => attr.name)
                 .sort(),
           nodeIsFragment(node)
             ? {}
             : Array.from(node.attributes).reduce<Record<string, string>>(
                 (props, attribute) => {
-                  props[attribute.name] = attribute.value
-                  return props
+                  props[attribute.name] = attribute.value;
+                  return props;
                 },
-                {},
+                {}
               ),
           config,
           indentation + config.indent,
           depth,
           refs,
-          printer,
+          printer
         ),
         printChildren(
           getChildren(node) as unknown[],
@@ -294,11 +304,11 @@ export function createDOMElementFilter(
           indentation + config.indent,
           depth,
           refs,
-          printer,
+          printer
         ),
         config,
-        indentation,
-      )
+        indentation
+      );
     },
-  }
+  };
 }

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -225,9 +225,8 @@ export function createDOMElementFilter(
   filterNode: (node: Node) => boolean,
 ): NewPlugin {
 
-  function getChildren (node: Element | DocumentFragment | ShadowRoot) {
-    const children = Array.prototype.slice
-      .call(node.childNodes || node.children)
+  function getChildren (node: Element | DocumentFragment | ShadowRoot): (Node | Element | ShadowRoot)[] {
+    const children: (Node | Element | ShadowRoot)[] = Array.prototype.slice.call(node.childNodes || node.children)
 
     if ("shadowRoot" in node && node.shadowRoot != null && node.shadowRoot.mode !== "closed") {
       children.unshift(node.shadowRoot)
@@ -290,7 +289,7 @@ export function createDOMElementFilter(
           printer,
         ),
         printChildren(
-          getChildren(node),
+          getChildren(node) as unknown[],
           config,
           indentation + config.indent,
           depth,

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -195,13 +195,15 @@ const testNode = (val: any) => {
   const { nodeType, tagName } = val;
   const isCustomElement =
     (typeof tagName === "string" && tagName.includes("-")) ||
-    (typeof val.hasAttribute === "function" && val.hasAttribute("is"));
+    (typeof val.hasAttribute === "function" && val.hasAttribute("is")) ||
+    val instanceof HTMLElement;
 
   return (
     (nodeType === ELEMENT_NODE &&
       (ELEMENT_REGEXP.test(constructorName) || isCustomElement)) ||
     (nodeType === TEXT_NODE && constructorName === "Text") ||
     (nodeType === COMMENT_NODE && constructorName === "Comment") ||
+    // Don't check constructorName === "DocumentFragment" because it excludes ShadowRoot.
     nodeType === FRAGMENT_NODE
   );
 };

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -1,75 +1,313 @@
-import { prettyDOM } from "@testing-library/dom";
-
 /**
  * This is an extension of prettyDOM / logDOM that provides proper printing of shadow roots.
+ * Pulled from here: https://github.com/AriPerkkio/aria-live-capture/blob/85f1e4613bec443797097320ed5f2b9f733fc729/.storybook/pretty-dom-with-shadow-dom.ts
  */
+import { prettyDOM } from "@testing-library/dom";
+import type { Config, NewPlugin, Printer, Refs } from "pretty-format";
+import { getAllElementsAndShadowRoots } from "./deep-query-selectors";
+
 export function prettyShadowDOM(
   ...args: Parameters<typeof prettyDOM>
 ): ReturnType<typeof prettyDOM> {
-  const [element, maxLength, options] = args;
-  return prettyDOM(toJSDOM(element), maxLength, options);
+  const [dom, maxLength, options] = args;
+
+  const plugin: NewPlugin = {
+    test: (val: any) => {
+      const bool = val?.constructor && testNode(val);
+      return bool;
+    },
+    serialize,
+  };
+
+  return prettyDOM(dom, maxLength, {
+    ...options,
+    plugins: [plugin],
+    filterNode: () => true,
+  });
 }
 
-export function toJSDOM(element?: Element | Document | undefined): HTMLElement {
-  if (element == null) element = document.documentElement;
-
-  let htmlString: string = "";
-
-  if ("outerHTML" in element) {
-    htmlString = element.outerHTML;
-  }
-
-  htmlString = processNodes(element, htmlString);
-
-  // Remove Comment nodes
-  htmlString = htmlString.replace(/<!--.*?-->/g, "");
-
-  // Remove extraneous whitespace as it creates bloated printing
-  htmlString = htmlString.replace(/>\s+</g, "><");
-
-  const parser = new DOMParser();
-  const dom = parser.parseFromString(htmlString, "text/html");
-
-  if (
-    element instanceof Document ||
-    element instanceof HTMLHtmlElement ||
-    element instanceof HTMLBodyElement
-  ) {
-    return dom.body;
-  }
-
-  return dom.body.firstElementChild as HTMLElement;
+function escapeHTML(str: string): string {
+  return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function processNodes(
-  element: Element | Document | ShadowRoot,
-  stringBuffer: string = "",
-  nodes: Array<Element | ShadowRoot | Document> = Array.from(element.children)
-) {
-  if ("shadowRoot" in element && element.shadowRoot != null) {
-    nodes.unshift(element.shadowRoot);
+// Return empty string if keys is empty.
+function printProps(
+  keys: Array<string>,
+  props: Record<string, unknown>,
+  config: Config,
+  indentation: string,
+  depth: number,
+  refs: Refs,
+  printer: Printer
+): string {
+  const indentationNext = indentation + config.indent;
+  const colors = config.colors;
+  return keys
+    .map((key) => {
+      const value = props[key];
+      let printed = printer(value, config, indentationNext, depth, refs);
+
+      if (typeof value !== "string") {
+        if (printed.indexOf("\n") !== -1) {
+          printed =
+            config.spacingOuter +
+            indentationNext +
+            printed +
+            config.spacingOuter +
+            indentation;
+        }
+        printed = "{" + printed + "}";
+      }
+
+      return (
+        config.spacingInner +
+        indentation +
+        colors.prop.open +
+        key +
+        colors.prop.close +
+        "=" +
+        colors.value.open +
+        printed +
+        colors.value.close
+      );
+    })
+    .join("");
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#node_type_constants
+const NodeTypeTextNode = 3;
+
+// Return empty string if children is empty.
+const printChildren = (
+  children: Array<unknown>,
+  config: Config,
+  indentation: string,
+  depth: number,
+  refs: Refs,
+  printer: Printer
+): string =>
+  children
+    .map((child) => {
+      const printedChild =
+        typeof child === "string"
+          ? printText(child, config)
+          : printer(child, config, indentation, depth, refs);
+
+      if (
+        printedChild === "" &&
+        typeof child === "object" &&
+        child !== null &&
+        (child as Node).nodeType !== NodeTypeTextNode
+      ) {
+        // A plugin serialized this Node to '' meaning we should ignore it.
+        return "";
+      }
+      return config.spacingOuter + indentation + printedChild;
+    })
+    .join("");
+
+const printText = (text: string, config: Config): string => {
+  const contentColor = config.colors.content;
+  return contentColor.open + escapeHTML(text) + contentColor.close;
+};
+
+const printComment = (comment: string, config: Config): string => {
+  const commentColor = config.colors.comment;
+  return (
+    commentColor.open +
+    "<!--" +
+    escapeHTML(comment) +
+    "-->" +
+    commentColor.close
+  );
+};
+
+// Separate the functions to format props, children, and element,
+// so a plugin could override a particular function, if needed.
+// Too bad, so sad: the traditional (but unnecessary) space
+// in a self-closing tagColor requires a second test of printedProps.
+const printElement = (
+  type: string,
+  printedProps: string,
+  printedChildren: string,
+  hasShadowRoot: boolean,
+  config: Config,
+  indentation: string
+): string => {
+  const tagColor = config.colors.tag;
+  const shadowRootMarkup = hasShadowRoot
+    ? `${config.spacingOuter + indentation}  #shadow-root`
+    : "";
+
+  return (
+    tagColor.open +
+    "<" +
+    type +
+    (printedProps &&
+      tagColor.close +
+        printedProps +
+        config.spacingOuter +
+        indentation +
+        tagColor.open) +
+    (printedChildren
+      ? ">" +
+        shadowRootMarkup +
+        tagColor.close +
+        printedChildren +
+        config.spacingOuter +
+        indentation +
+        tagColor.open +
+        "</" +
+        type
+      : (printedProps && !config.min ? "" : " ") + "/") +
+    ">" +
+    tagColor.close
+  );
+};
+
+const printElementAsLeaf = (type: string, config: Config): string => {
+  const tagColor = config.colors.tag;
+  return (
+    tagColor.open +
+    "<" +
+    type +
+    tagColor.close +
+    " …" +
+    tagColor.open +
+    " />" +
+    tagColor.close
+  );
+};
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const COMMENT_NODE = 8;
+const FRAGMENT_NODE = 11;
+
+const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/;
+
+const testNode = (val: any) => {
+  const constructorName = val.constructor.name;
+  const { nodeType, tagName } = val;
+  const isCustomElement =
+    (typeof tagName === "string" && tagName.includes("-")) ||
+    (typeof val.hasAttribute === "function" && val.hasAttribute("is"));
+
+  return (
+    (nodeType === ELEMENT_NODE &&
+      (ELEMENT_REGEXP.test(constructorName) || isCustomElement)) ||
+    (nodeType === TEXT_NODE && constructorName === "Text") ||
+    (nodeType === COMMENT_NODE && constructorName === "Comment") ||
+    (nodeType === FRAGMENT_NODE && constructorName === "DocumentFragment")
+  );
+};
+
+type HandledType = Element | Text | Comment | DocumentFragment;
+
+function nodeIsText(node: HandledType): node is Text {
+  return node.nodeType === TEXT_NODE;
+}
+
+function nodeIsComment(node: HandledType): node is Comment {
+  return node.nodeType === COMMENT_NODE;
+}
+
+function nodeIsFragment(node: HandledType): node is DocumentFragment {
+  return node.nodeType === FRAGMENT_NODE;
+}
+
+function serialize(
+  node: HandledType,
+  config: Config,
+  indentation: string,
+  depth: number,
+  refs: Refs,
+  printer: Printer
+): string {
+  if (nodeIsText(node)) {
+    return printText(node.data, config);
   }
 
-  nodes.unshift(element);
-
-  while (nodes.length > 0) {
-    const node = nodes.shift()!;
-    if (node && "shadowRoot" in node && node.shadowRoot != null) {
-      const outerHTML = node.outerHTML;
-
-      const shadowRootPseudoNode = document.createElement("shadow-root");
-      shadowRootPseudoNode.innerHTML = node.shadowRoot.innerHTML;
-
-      const clonedNode = node.cloneNode(true) as Element;
-      clonedNode.insertAdjacentElement("afterbegin", shadowRootPseudoNode);
-
-      stringBuffer = stringBuffer.replace(outerHTML, clonedNode.outerHTML);
-
-      stringBuffer = stringBuffer.replace(outerHTML, node.outerHTML);
-      nodes.push(...Array.from(node.shadowRoot.children));
-    }
-    nodes.push(...Array.from(node.children));
+  if (nodeIsComment(node)) {
+    return printComment(node.data, config);
   }
 
-  return stringBuffer;
+  const type = nodeIsFragment(node)
+    ? `DocumentFragment`
+    : node.tagName.toLowerCase();
+
+  if (++depth > config.maxDepth) {
+    return printElementAsLeaf(type, config);
+  }
+
+  const children = printChildren(
+    getChildren(node),
+    config,
+    indentation + config.indent,
+    depth,
+    refs,
+    printer
+  );
+
+  const hasShadowRoot = "shadowRoot" in node && node.shadowRoot != null;
+
+  return printElement(
+    type,
+    printProps(
+      nodeIsFragment(node)
+        ? []
+        : Array.from(node.attributes)
+            .map((attr) => attr.name)
+            .sort(),
+      nodeIsFragment(node)
+        ? {}
+        : Array.from(node.attributes).reduce<Record<string, string>>(
+            (props, attribute) => {
+              props[attribute.name] = attribute.value;
+              return props;
+            },
+            {}
+          ),
+      config,
+      indentation + config.indent,
+      depth,
+      refs,
+      printer
+    ),
+    children,
+    hasShadowRoot,
+    config,
+    indentation
+  );
+}
+
+function getChildren(node: Element | DocumentFragment, filterNode = () => true): Node[] {
+	return getAllChildNodes(node).filter(filterNode)
+}
+
+function getAllChildNodes (node: Node | ShadowRoot | Element | DocumentFragment, finalNodes: (Node | Element)[] = []): Node[] {
+	const nodes = getChildNodes(node)
+
+	nodes.forEach((childNode) => {
+		if (node == null) return
+
+		finalNodes.push(childNode)
+
+		if ("shadowRoot" in childNode && childNode.shadowRoot != null && childNode.shadowRoot.mode === "open") {
+			getAllChildNodes(childNode.shadowRoot, finalNodes)
+		}
+
+		getAllChildNodes(childNode, finalNodes)
+	})
+
+
+	return finalNodes as Node[]
+}
+
+function getChildNodes (node: Element | Node): (Node | Element)[] {
+	if ("children" in node) {
+		return Array.prototype.slice.call(node.childNodes || node.children)
+	}
+
+	return Array.prototype.slice.call(node.childNodes)
 }

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -10,15 +10,10 @@ export function prettyShadowDOM(
     options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
   );
 
-  if (options?.plugins) {
-    options.plugins.push(plugin);
-  } else {
-    if (options == null) {
-      options = {};
-    }
+  if (options == null) options = {}
+  if (options.plugins == null) options.plugins = []
 
-    options.plugins = [plugin];
-  }
+  options.plugins.push(plugin);
 
   return prettyDOM(dom, maxLength, {
     ...options,
@@ -30,7 +25,7 @@ function escapeHTML(str: string): string {
   return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function filterCommentsAndDefaultIgnoreTagsTags(value: Node) {
+export function filterCommentsAndDefaultIgnoreTagsTags(value: Node) {
   return (
     value.nodeType !== COMMENT_NODE &&
     (value.nodeType !== ELEMENT_NODE ||


### PR DESCRIPTION
Use a real shadowDOM printer!

fixes #42 

There needs to be some more robust testing, but in manually checking triple-nested-shadow-roots it works as expected.

```
stdout | __tests__/pretty-shadow-dom.test.tsx > It should render 3 shadow root instances
<body>
  <div>
    <triple-shadow-roots>
      <ShadowRoot>


        <nested-shadow-roots>
          <ShadowRoot>


            <duplicate-buttons>
              <ShadowRoot>


                <slot
                  name="start"
                />


                <button>
                  Button One
                </button>


                <br />


                <slot />


                <br />


                <button>
                  Button Two
                </button>


                <slot
                  name="end"
                />


              </ShadowRoot>
            </duplicate-buttons>


          </ShadowRoot>


        </nested-shadow-roots>


      </ShadowRoot>
    </triple-shadow-roots>
  </div>
</body>

```

There's large amount of white space due to how `node.childNodes` works. This is expected and how prettyDOM works today due to "significant whitespace"

I'll look to see if theres a way to strip this out in the future.