### PR TITLE
feat: set the default `getElementError` to use prettyShadowDOM

### DIFF
--- a/__tests__/patch-testing-library-plugin.test.tsx
+++ b/__tests__/patch-testing-library-plugin.test.tsx
@@ -1,0 +1,14 @@
+import * as React from "react"
+import {
+  render,
+  // screen
+} from "@testing-library/react"
+import { screen } from "../src/index"
+import { TripleShadowRoots } from "../components";
+
+test("Should serialize custom elements properly", () => {
+  render(<TripleShadowRoots />);
+  // const btn = screen.getByShadowText("button")
+  const btn = screen.getByRole("button")
+  expect(btn).toBeInTheDocument()
+});

--- a/__tests__/patch-testing-library-plugin.test.tsx
+++ b/__tests__/patch-testing-library-plugin.test.tsx
@@ -4,11 +4,16 @@ import {
   // screen
 } from "@testing-library/react"
 import { screen } from "../src/index"
-import { TripleShadowRoots } from "../components";
+import { TripleShadowRoots, Duplicates } from "../components";
 
 test("Should serialize custom elements properly", () => {
-  render(<TripleShadowRoots />);
-  // const btn = screen.getByShadowText("button")
-  const btn = screen.getByRole("button")
+  render(
+    <TripleShadowRoots>
+      <button>Button</button>
+      <Duplicates />
+    </TripleShadowRoots>
+  );
+  const btn = screen.getByShadowRole("button", { name: "Not found" })
+  // const btn = screen.getByRole("button", { name: "Not found" })
   expect(btn).toBeInTheDocument()
 });

--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -143,6 +143,7 @@ test("It should render 3 shadow root instances", () => {
                     [36m/>[39m[0m
                   [36m</ShadowRoot>[39m
                 [36m</duplicate-buttons>[39m[0m
+                [36m<slot />[39m[0m
               [36m</ShadowRoot>[39m[0m
             [36m</nested-shadow-roots>[39m[0m
           [36m</ShadowRoot>[39m

--- a/__tests__/role-not-found.test.tsx
+++ b/__tests__/role-not-found.test.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
+import * as React from "react";
 import {
   render,
   // screen
-} from "@testing-library/react"
-import { screen } from "../src/index"
+} from "@testing-library/react";
+import { screen } from "../src/index";
 import { TripleShadowRoots, NestedShadowRoots } from "../components";
 
 // Replication of: https://github.com/KonnorRogers/shadow-dom-testing-library/issues/47
@@ -14,6 +14,6 @@ test.skip("Should serialize custom elements properly", () => {
     </TripleShadowRoots>
   );
   // const btn = screen.getByShadowRole("button", { name: "Not found" })
-  const btn = screen.getByRole("button")
-  expect(btn).toBeInTheDocument()
+  const btn = screen.getByRole("button");
+  expect(btn).toBeInTheDocument();
 });

--- a/__tests__/role-not-found.test.tsx
+++ b/__tests__/role-not-found.test.tsx
@@ -6,7 +6,8 @@ import {
 import { screen } from "../src/index"
 import { TripleShadowRoots, NestedShadowRoots } from "../components";
 
-test("Should serialize custom elements properly", () => {
+// Replication of: https://github.com/KonnorRogers/shadow-dom-testing-library/issues/47
+test.skip("Should serialize custom elements properly", () => {
   render(
     <TripleShadowRoots>
       <NestedShadowRoots role="not-button" />

--- a/__tests__/role-not-found.test.tsx
+++ b/__tests__/role-not-found.test.tsx
@@ -4,16 +4,15 @@ import {
   // screen
 } from "@testing-library/react"
 import { screen } from "../src/index"
-import { TripleShadowRoots, Duplicates } from "../components";
+import { TripleShadowRoots, NestedShadowRoots } from "../components";
 
 test("Should serialize custom elements properly", () => {
   render(
     <TripleShadowRoots>
-      <button>Button</button>
-      <Duplicates />
+      <NestedShadowRoots role="not-button" />
     </TripleShadowRoots>
   );
-  const btn = screen.getByShadowRole("button", { name: "Not found" })
-  // const btn = screen.getByRole("button", { name: "Not found" })
+  // const btn = screen.getByShadowRole("button", { name: "Not found" })
+  const btn = screen.getByRole("button")
   expect(btn).toBeInTheDocument()
 });

--- a/components.tsx
+++ b/components.tsx
@@ -116,6 +116,8 @@ class NestedShadowRootsElement extends HTMLElement {
 
     this.shadowRoot.innerHTML = `
 			<duplicate-buttons></duplicate-buttons>
+
+			<slot></slot>
 		`;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ import { debug } from "./debug";
 import { logShadowDOM } from "./log-shadow-dom";
 import { prettyShadowDOM } from "./pretty-shadow-dom";
 import { shadowScreen } from "./shadow-screen";
-import { patchWrap } from "./trick-dom-testing-library";
 
 configure({
+  // https://github.com/testing-library/dom-testing-library/blob/39a64d4b862f706d09f0cd225ce9eda892f1e8d8/src/config.ts#L36-L51
   getElementError (message, container) {
     const prettifiedDOM = prettyShadowDOM(container)
     const error = new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,20 +8,22 @@ import { shadowScreen } from "./shadow-screen";
 
 configure({
   // https://github.com/testing-library/dom-testing-library/blob/39a64d4b862f706d09f0cd225ce9eda892f1e8d8/src/config.ts#L36-L51
-  getElementError (message, container) {
-    const prettifiedDOM = prettyShadowDOM(container)
+  getElementError(message, container) {
+    const prettifiedDOM = prettyShadowDOM(container);
     const error = new Error(
       [
         message,
-        `Ignored nodes: comments, ${getConfig().defaultIgnore}\n${prettifiedDOM}`,
+        `Ignored nodes: comments, ${
+          getConfig().defaultIgnore
+        }\n${prettifiedDOM}`,
       ]
         .filter(Boolean)
-        .join('\n\n'),
-    )
-    error.name = 'ShadowDOMTestingLibraryElementError'
-    return error
-  }
-})
+        .join("\n\n")
+    );
+    error.name = "ShadowDOMTestingLibraryElementError";
+    return error;
+  },
+});
 
 const allQueries = {
   ...queries,
@@ -35,9 +37,7 @@ function shadowWithin(element: HTMLElement) {
 export * from "./types";
 export * from "./shadow-queries";
 
-export {
-  createDOMElementFilter
-} from "./pretty-shadow-dom"
+export { createDOMElementFilter } from "./pretty-shadow-dom";
 
 export {
   deepQuerySelector,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { queries, within } from "@testing-library/dom";
+import { queries, within, configure, getConfig } from "@testing-library/dom";
 
 import * as shadowQueries from "./shadow-queries";
 import { debug } from "./debug";
@@ -6,6 +6,22 @@ import { logShadowDOM } from "./log-shadow-dom";
 import { prettyShadowDOM } from "./pretty-shadow-dom";
 import { shadowScreen } from "./shadow-screen";
 import { patchWrap } from "./trick-dom-testing-library";
+
+configure({
+  getElementError (message, container) {
+    const prettifiedDOM = prettyShadowDOM(container)
+    const error = new Error(
+      [
+        message,
+        `Ignored nodes: comments, ${getConfig().defaultIgnore}\n${prettifiedDOM}`,
+      ]
+        .filter(Boolean)
+        .join('\n\n'),
+    )
+    error.name = 'ShadowDOMTestingLibraryElementError'
+    return error
+  }
+})
 
 const allQueries = {
   ...queries,
@@ -18,6 +34,10 @@ function shadowWithin(element: HTMLElement) {
 
 export * from "./types";
 export * from "./shadow-queries";
+
+export {
+  createDOMElementFilter
+} from "./pretty-shadow-dom"
 
 export {
   deepQuerySelector,


### PR DESCRIPTION
- out of the box better errors for shadow dom

fixes #47 