### PR TITLE
fix(types): add TypeScript generics for queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,6 @@ screen.getByShadowRole("button");
 ```ts
 import { screen, shadowQueries } from "shadow-dom-testing-library";
 
-const btn = await screen.findByShadowRole<HTMLButtonElement>("button")
-const btn = shadowQueries.getByShadowRole<HTMLButtonElement>("button")
+const btn = await screen.findByShadowRole<HTMLButtonElement>("button");
+const btn = shadowQueries.getByShadowRole<HTMLButtonElement>("button");
 ```

--- a/README.md
+++ b/README.md
@@ -280,3 +280,12 @@ const screen = {
 
 screen.getByShadowRole("button");
 ```
+
+## Usage with TypeScript
+
+```ts
+import { screen, shadowQueries } from "shadow-dom-testing-library";
+
+const btn = await screen.findByShadowRole<HTMLButtonElement>("button")
+const btn = shadowQueries.getByShadowRole<HTMLButtonElement>("button")
+```

--- a/__tests__/deep-query-selectors.test.tsx
+++ b/__tests__/deep-query-selectors.test.tsx
@@ -15,13 +15,13 @@ describe("deepQuerySelector()", () => {
       ?.shadowRoot?.querySelectorAll("button")[1];
 
     expect(deepQuerySelector(container, "button")).toBeInstanceOf(
-      HTMLButtonElement
+      HTMLButtonElement,
     );
     expect(deepQuerySelector(container, "button")).toBe(btn);
     expect(deepQuerySelector(container, "button")).not.toBe(secondButton);
 
     expect(deepQuerySelector(baseElement, "button")).toBeInstanceOf(
-      HTMLButtonElement
+      HTMLButtonElement,
     );
     expect(deepQuerySelector(baseElement, "button")).toBe(btn);
     expect(deepQuerySelector(baseElement, "button")).not.toBe(secondButton);
@@ -58,7 +58,7 @@ describe("deepQuerySelectorAll()", () => {
 
     btns = deepQuerySelectorAll(
       document.querySelector("duplicate-buttons") as HTMLElement,
-      "button"
+      "button",
     );
     expect(btns).toHaveLength(2);
     btns.forEach((btn) => expect(btn).toBeInstanceOf(HTMLButtonElement));

--- a/__tests__/duplicateNodes.test.tsx
+++ b/__tests__/duplicateNodes.test.tsx
@@ -19,12 +19,12 @@ test("Should error if two similiar nodes actually exist", async () => {
     <>
       <h2>Hello</h2>
       <h2>Hello</h2>
-    </>
+    </>,
   );
 
   expect(() => screen.getByShadowText("Hello")).toThrow(/multiple elements/i);
   await expect(() => screen.findByShadowText("Hello")).rejects.toThrow(
-    /multiple elements/i
+    /multiple elements/i,
   );
 });
 
@@ -32,7 +32,7 @@ test("Should error if two similar nodes are in shadow root", async () => {
   render(<Duplicates />);
   expect(() => screen.getByShadowRole("button")).toThrow(/multiple elements/i);
   await expect(() => screen.findByShadowRole("button")).rejects.toThrow(
-    /multiple elements/i
+    /multiple elements/i,
   );
 });
 
@@ -41,7 +41,7 @@ test("Should find duplicate nodes in a double nested shadow root", async () => {
 
   expect(() => screen.getByShadowRole("button")).toThrow(/multiple elements/i);
   await expect(() => screen.findByShadowRole("button")).rejects.toThrow(
-    /multiple elements/i
+    /multiple elements/i,
   );
 });
 
@@ -50,6 +50,6 @@ test("Should find duplicate nodes in a triple nested shadow root", async () => {
 
   expect(() => screen.getByShadowRole("button")).toThrow(/multiple elements/i);
   await expect(() => screen.findByShadowRole("button")).rejects.toThrow(
-    /multiple elements/i
+    /multiple elements/i,
   );
 });

--- a/__tests__/role-not-found.test.tsx
+++ b/__tests__/role-not-found.test.tsx
@@ -11,7 +11,7 @@ test.skip("Should serialize custom elements properly", () => {
   render(
     <TripleShadowRoots>
       <NestedShadowRoots role="not-button" />
-    </TripleShadowRoots>
+    </TripleShadowRoots>,
   );
   // const btn = screen.getByShadowRole("button", { name: "Not found" })
   const btn = screen.getByRole("button");

--- a/__tests__/screenDebug.test.tsx
+++ b/__tests__/screenDebug.test.tsx
@@ -30,7 +30,7 @@ test("Single shadow root", async () => {
       <div slot="start">Start Slot</div>
       <div>Default Slot</div>
       <div slot="end">End Slot</div>
-    </Duplicates>
+    </Duplicates>,
   );
 
   screen.debug();

--- a/__tests__/shadowAltText.test.tsx
+++ b/__tests__/shadowAltText.test.tsx
@@ -12,31 +12,31 @@ describe("ShadowAltText()", () => {
     });
     expect(findContainerAlt).toBeInTheDocument();
     const findContainerAlts = await screen.findAllByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(findContainerAlts.length).toBeGreaterThan(0);
 
     const queryContainerAlt = screen.queryByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(queryContainerAlt).toBeInTheDocument();
     const queryContainerAlts = screen.queryAllByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(queryContainerAlts.length).toBeGreaterThan(0);
 
     const getContainerAlt = screen.getByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(getContainerAlt).toBeInTheDocument();
     const getContainerAlts = screen.getAllByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(getContainerAlts.length).toBeGreaterThan(0);
 
     // // Use await findByX to let things render then use other calls.
     const findAlt = await screen.findByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(findAlt).toBeInTheDocument();
     const findAlts = await screen.findAllByShadowAltText(/shoes/, {
@@ -45,20 +45,20 @@ describe("ShadowAltText()", () => {
     expect(findAlts.length).toBeGreaterThan(0);
 
     const queryAlt = screen.queryByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(queryAlt).toBeInTheDocument();
     const queryAlts = screen.queryAllByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(queryAlts.length).toBeGreaterThan(0);
 
     const getAlt = screen.getByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(getAlt).toBeInTheDocument();
     const getAlts = screen.getAllByShadowAltText(
-      "Animation of untied shoes walking on pavement"
+      "Animation of untied shoes walking on pavement",
     );
     expect(getAlts.length).toBeGreaterThan(0);
   });

--- a/__tests__/shadowLabelText.test.tsx
+++ b/__tests__/shadowLabelText.test.tsx
@@ -11,12 +11,11 @@ describe("ByShadowLabelText()", () => {
     const findContainerLabel = await findByShadowLabelText(
       container,
       /omments/,
-      { exact: false }
+      { exact: false },
     );
     expect(findContainerLabel).toBeInTheDocument();
-    const findContainerLabels = await screen.findAllByShadowLabelText(
-      "Comments"
-    );
+    const findContainerLabels =
+      await screen.findAllByShadowLabelText("Comments");
     expect(findContainerLabels.length).toBeGreaterThan(0);
 
     const queryContainerLabel = screen.queryByShadowLabelText("Comments");

--- a/__tests__/shadowText.test.tsx
+++ b/__tests__/shadowText.test.tsx
@@ -30,7 +30,7 @@ describe("ShadowText()", () => {
     });
 
     const el = (await fixture(
-      html`<shadow-text></shadow-text>`
+      html`<shadow-text></shadow-text>`,
     )) as HTMLElement;
     await nextFrame();
 
@@ -50,7 +50,7 @@ describe("ShadowText()", () => {
 
   it("should not suggest light dom queries", async () => {
     const el = (await fixture(
-      html`<shadow-text></shadow-text>`
+      html`<shadow-text></shadow-text>`,
     )) as HTMLElement;
     await nextFrame();
 

--- a/__tests__/slot-aggregation.test.tsx
+++ b/__tests__/slot-aggregation.test.tsx
@@ -10,11 +10,11 @@ test("Should aggregate content from slots", async () => {
         <img src="" /> <span>Start button</span>
       </button>
       <a href="#">Middle Link</a>
-    </Duplicates>
+    </Duplicates>,
   );
 
   const startSlot = el.container.firstElementChild?.shadowRoot?.querySelector(
-    "slot[name='start']"
+    "slot[name='start']",
   ) as HTMLSlotElement;
   const btn = await within(startSlot).findAllByShadowRole("button");
   expect(btn.length).toEqual(1);
@@ -25,14 +25,14 @@ test("Should aggregate content from slots", async () => {
   expect(within(startSlot).queryByShadowRole("link")).toBeNull;
 
   const defaultSlot = el.container.firstElementChild?.shadowRoot?.querySelector(
-    "slot:not([name])"
+    "slot:not([name])",
   ) as HTMLSlotElement;
   const anchor = await within(defaultSlot).findByShadowRole("link");
   expect(anchor).toBeInTheDocument();
 
   // Make sure default slot doesnt pick up start / end slot
   expect(
-    within(defaultSlot).queryByShadowRole("button")
+    within(defaultSlot).queryByShadowRole("button"),
   ).not.toBeInTheDocument();
   expect(within(defaultSlot).queryByShadowRole("img")).not.toBeInTheDocument();
 
@@ -44,11 +44,11 @@ test("slot aggregation should use slotted content instead of default content", (
   const el = render(
     <Select label="My Other Label">
       <span slot="label">My Label</span>
-    </Select>
+    </Select>,
   );
 
   const labelSlot = el.container.firstElementChild?.shadowRoot?.querySelector(
-    "slot[name='label']"
+    "slot[name='label']",
   ) as HTMLSlotElement;
 
   expect(within(labelSlot).queryByText("My Label")).toBeTruthy;
@@ -58,7 +58,7 @@ test("slot aggregation should use default items when not given slotted content",
   const el = render(<Select label="My Label"></Select>);
 
   const labelSlot = el.container.firstElementChild?.shadowRoot?.querySelector(
-    "slot[name='label']"
+    "slot[name='label']",
   ) as HTMLSlotElement;
 
   expect(within(labelSlot).queryByText("My Label")).toBeTruthy;

--- a/__tests__/within.test.tsx
+++ b/__tests__/within.test.tsx
@@ -12,7 +12,7 @@ describe("within", () => {
       <Select label={selectLabel}>
         <option>{optionLabel}</option>
         <option>Option two</option>
-      </Select>
+      </Select>,
     );
 
     const shadowSelect = await screen.findByShadowRole("combobox");
@@ -30,7 +30,7 @@ describe("within", () => {
   it("Should find the nested button", async () => {
     render(<Duplicates />);
     const btns = await within(
-      document.querySelector("duplicate-buttons") as HTMLElement
+      document.querySelector("duplicate-buttons") as HTMLElement,
     ).findAllByShadowRole("button");
     expect(btns).toHaveLength(2);
     btns.forEach((btn) => expect(btn).toBeInstanceOf(HTMLButtonElement));

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "jest-environment-jsdom": "^28.1.2",
         "jest-preview": "^0.2.6",
         "jsdom": "^20.0.2",
+        "prettier": "^3.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "standard-version": "^9.5.0",
@@ -7559,6 +7560,21 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -15426,6 +15442,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "test": "vitest run",
-    "format": "npx prettier ./src ./__tests__ ./README.md --write",
-    "check": "npx prettier ./src ./__tests__ ./README.md --check",
+    "format": "prettier ./src ./__tests__ ./README.md --write",
+    "check": "prettier ./src ./__tests__ ./README.md --check",
     "test:watch": "vitest",
     "test:ci": "npm run build && npm run test && npm run jest",
     "jest": "jest",
@@ -64,6 +64,7 @@
     "jest-environment-jsdom": "^28.1.2",
     "jest-preview": "^0.2.6",
     "jsdom": "^20.0.2",
+    "prettier": "^3.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "standard-version": "^9.5.0",

--- a/src/deep-query-selectors.ts
+++ b/src/deep-query-selectors.ts
@@ -4,7 +4,7 @@ import { Container, ShadowOptions } from "./types";
 export function deepQuerySelector<T extends HTMLElement>(
   container: Container,
   selector: string,
-  options: ShadowOptions = { shallow: false }
+  options: ShadowOptions = { shallow: false },
 ): T | null {
   const els = deepQuerySelectorAll(container, selector, options);
 
@@ -30,7 +30,7 @@ export function deepQuerySelector<T extends HTMLElement>(
 export function deepQuerySelectorAll<T extends HTMLElement>(
   container: Container,
   selector: string,
-  options: ShadowOptions = { shallow: false }
+  options: ShadowOptions = { shallow: false },
 ): T[] {
   return patchWrap(() => {
     const elements = getAllElementsAndShadowRoots(container, options);
@@ -46,7 +46,7 @@ export function deepQuerySelectorAll<T extends HTMLElement>(
 // maybe an infinite generator in the future?
 export function getAllElementsAndShadowRoots(
   container: Container,
-  options: ShadowOptions = { shallow: false }
+  options: ShadowOptions = { shallow: false },
 ) {
   const selector = "*";
   return recurse(container, selector, options);
@@ -57,7 +57,7 @@ function recurse(
   selector: string,
   options: ShadowOptions = { shallow: false },
   elementsToProcess: (Element | ShadowRoot | Document)[] = [],
-  elements: (Element | ShadowRoot | Document)[] = []
+  elements: (Element | ShadowRoot | Document)[] = [],
 ) {
   // if "document" is passed in, it will also pick up "<html>" causing the query to run twice.
   if (container instanceof Document) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ configure({
         }\n${prettifiedDOM}`,
       ]
         .filter(Boolean)
-        .join("\n\n")
+        .join("\n\n"),
     );
     error.name = "ShadowDOMTestingLibraryElementError";
     return error;

--- a/src/log-shadow-dom.ts
+++ b/src/log-shadow-dom.ts
@@ -12,7 +12,7 @@ export function logShadowDOM(
   let [dom, maxLength, options] = args;
 
   const plugin: NewPlugin = createDOMElementFilter(
-    options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
+    options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags,
   );
 
   if (options == null) options = {};

--- a/src/pretty-shadow-dom.ts
+++ b/src/pretty-shadow-dom.ts
@@ -8,7 +8,7 @@ const findWhiteSpace = /([^\S\r\n]*[\f\n\r\t\v]+)/.source;
 function removeDuplicateNewLines(str: string) {
   let final = str.replace(
     new RegExp(`${findWhiteSpace}.*${findWhiteSpace}{2,}`, "g"),
-    ""
+    "",
   );
   return final;
 }
@@ -19,7 +19,7 @@ export function prettyShadowDOM(
   let [dom, maxLength, options] = args;
 
   const plugin: NewPlugin = createDOMElementFilter(
-    options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags
+    options?.filterNode || filterCommentsAndDefaultIgnoreTagsTags,
   );
 
   if (options == null) options = {};
@@ -31,7 +31,7 @@ export function prettyShadowDOM(
     prettyDOM(dom, maxLength, {
       ...options,
       plugins: [plugin],
-    })
+    }),
   );
 }
 
@@ -56,7 +56,7 @@ const printProps = (
   indentation: string,
   depth: number,
   refs: Refs,
-  printer: Printer
+  printer: Printer,
 ): string => {
   const indentationNext = indentation + config.indent;
   const colors = config.colors;
@@ -103,7 +103,7 @@ const printChildren = (
   indentation: string,
   depth: number,
   refs: Refs,
-  printer: Printer
+  printer: Printer,
 ): string =>
   removeDuplicateNewLines(
     children
@@ -124,7 +124,7 @@ const printChildren = (
         }
         return config.spacingOuter + indentation + printedChild;
       })
-      .join("")
+      .join(""),
   );
 
 const printText = (text: string, config: Config): string => {
@@ -152,7 +152,7 @@ const printElement = (
   printedProps: string,
   printedChildren: string,
   config: Config,
-  indentation: string
+  indentation: string,
 ): string => {
   const tagColor = config.colors.tag;
 
@@ -234,16 +234,16 @@ function nodeIsComment(node: HandledType): node is Comment {
 }
 
 function nodeIsFragment(
-  node: HandledType
+  node: HandledType,
 ): node is DocumentFragment | ShadowRoot {
   return node.nodeType === FRAGMENT_NODE;
 }
 
 export function createDOMElementFilter(
-  filterNode: (node: Node) => boolean
+  filterNode: (node: Node) => boolean,
 ): NewPlugin {
   function getChildren(
-    node: Element | DocumentFragment | ShadowRoot
+    node: Element | DocumentFragment | ShadowRoot,
   ): (Node | Element | ShadowRoot)[] {
     const children: (Node | Element | ShadowRoot)[] =
       Array.prototype.slice.call(node.childNodes || node.children);
@@ -267,7 +267,7 @@ export function createDOMElementFilter(
       indentation: string,
       depth: number,
       refs: Refs,
-      printer: Printer
+      printer: Printer,
     ) => {
       if (nodeIsText(node)) {
         return printText(node.data, config);
@@ -304,13 +304,13 @@ export function createDOMElementFilter(
                   props[attribute.name] = attribute.value;
                   return props;
                 },
-                {}
+                {},
               ),
           config,
           indentation + config.indent,
           depth,
           refs,
-          printer
+          printer,
         ),
         printChildren(
           getChildren(node) as unknown[],
@@ -318,10 +318,10 @@ export function createDOMElementFilter(
           indentation + config.indent,
           depth,
           refs,
-          printer
+          printer,
         ),
         config,
-        indentation
+        indentation,
       );
     },
   };

--- a/src/shadow-queries.ts
+++ b/src/shadow-queries.ts
@@ -10,6 +10,21 @@ import {
   queryAllByAltText,
   queryAllByTitle,
   queryAllByTestId,
+  AllByRole,
+  AllByText,
+  AllByBoundAttribute,
+  GetByRole,
+  QueryByRole,
+  FindByRole,
+  FindAllByRole,
+  QueryByText,
+  GetByText,
+  FindAllByText,
+  FindByText,
+  QueryByBoundAttribute,
+  GetByBoundAttribute,
+  FindAllByBoundAttribute,
+  FindByBoundAttribute,
 } from "@testing-library/dom";
 
 import { getAllElementsAndShadowRoots } from "./deep-query-selectors";
@@ -37,7 +52,7 @@ function toShadowQueries<T extends Function[]>(queries: T): T {
 // Role
 function queryAllByShadowRole<T extends HTMLElement = HTMLElement>(
   ...args: ShadowRoleMatcherParams
-): T[] {
+): ReturnType<AllByRole<T>> {
   let [container, role, options] = args;
 
   if (options == null) {
@@ -51,8 +66,8 @@ function queryAllByShadowRole<T extends HTMLElement = HTMLElement>(
       patchWrap(() =>
         getAllElementsAndShadowRoots(container, options)
           .map((el) => queryAllByRole(el as HTMLElement, role, options))
-          .flat(Infinity)
-      )
+          .flat(Infinity),
+      ),
     ),
   ] as T[];
 }
@@ -63,23 +78,39 @@ const getMissingRoleError = (_c: Element | null, role: ByRoleMatcher) =>
   `Unable to find an element with the role of: ${role}`;
 
 const [
-  queryByShadowRole,
-  getAllByShadowRole,
-  getByShadowRole,
-  findAllByShadowRole,
-  findByShadowRole,
+  _queryByShadowRole,
+  _getAllByShadowRole,
+  _getByShadowRole,
+  _findAllByShadowRole,
+  _findByShadowRole,
 ] = toShadowQueries(
   buildQueries<ScreenShadowRoleMatcherParams>(
     queryAllByShadowRole,
     getMultipleRoleError,
-    getMissingRoleError
-  )
+    getMissingRoleError,
+  ),
 );
+
+const queryByShadowRole = <T extends HTMLElement>(
+  ...args: Parameters<typeof _queryByShadowRole>
+) => _queryByShadowRole(...args) as ReturnType<QueryByRole<T>>;
+const getAllByShadowRole = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getAllByShadowRole>
+) => _getAllByShadowRole(...args) as Array<ReturnType<GetByRole<T>>>;
+const getByShadowRole = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getByShadowRole>
+) => _getByShadowRole(...args) as ReturnType<GetByRole<T>>;
+const findAllByShadowRole = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findAllByShadowRole>
+) => _findAllByShadowRole(...args) as ReturnType<FindAllByRole<T>>;
+const findByShadowRole = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findByShadowRole>
+) => _findByShadowRole(...args) as ReturnType<FindByRole<T>>;
 
 // Label Text
 function queryAllByShadowLabelText<T extends HTMLElement = HTMLElement>(
   ...args: ShadowSelectorMatcherParams
-): T[] {
+): ReturnType<AllByText<T>> {
   let [container, id, options] = args;
 
   if (options == null) {
@@ -93,8 +124,8 @@ function queryAllByShadowLabelText<T extends HTMLElement = HTMLElement>(
       patchWrap(() =>
         getAllElementsAndShadowRoots(container, options)
           .map((el) => queryAllByLabelText(el as HTMLElement, id, options))
-          .flat(Infinity)
-      )
+          .flat(Infinity),
+      ),
     ),
   ] as T[];
 }
@@ -105,23 +136,39 @@ const getMissingLabelTextError = (_c: Element | null, id: Matcher) =>
   `Unable to find an element with the label text of: ${id}`;
 
 const [
-  queryByShadowLabelText,
-  getAllByShadowLabelText,
-  getByShadowLabelText,
-  findAllByShadowLabelText,
-  findByShadowLabelText,
+  _queryByShadowLabelText,
+  _getAllByShadowLabelText,
+  _getByShadowLabelText,
+  _findAllByShadowLabelText,
+  _findByShadowLabelText,
 ] = toShadowQueries(
   buildQueries<ScreenShadowSelectorMatcherParams>(
     queryAllByShadowLabelText,
     getMultipleLabelTextError,
-    getMissingLabelTextError
-  )
+    getMissingLabelTextError,
+  ),
 );
+
+const queryByShadowLabelText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _queryByShadowLabelText>
+) => _queryByShadowLabelText(...args) as ReturnType<QueryByText<T>>;
+const getAllByShadowLabelText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getAllByShadowLabelText>
+) => _getAllByShadowLabelText(...args) as Array<ReturnType<GetByText<T>>>;
+const getByShadowLabelText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getByShadowLabelText>
+) => _getByShadowLabelText(...args) as ReturnType<GetByText<T>>;
+const findAllByShadowLabelText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findAllByShadowLabelText>
+) => _findAllByShadowLabelText(...args) as ReturnType<FindAllByText<T>>;
+const findByShadowLabelText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findByShadowLabelText>
+) => _findByShadowLabelText(...args) as ReturnType<FindByText<T>>;
 
 // Placeholder Text
 function queryAllByShadowPlaceholderText<T extends HTMLElement = HTMLElement>(
   ...args: ShadowMatcherParams
-): T[] {
+): ReturnType<AllByText<T>> {
   let [container, id, options] = args;
 
   if (options == null) {
@@ -135,10 +182,10 @@ function queryAllByShadowPlaceholderText<T extends HTMLElement = HTMLElement>(
       patchWrap(() =>
         getAllElementsAndShadowRoots(container, options)
           .map((el) =>
-            queryAllByPlaceholderText(el as HTMLElement, id, options)
+            queryAllByPlaceholderText(el as HTMLElement, id, options),
           )
-          .flat(Infinity)
-      )
+          .flat(Infinity),
+      ),
     ),
   ] as T[];
 }
@@ -149,23 +196,39 @@ const getMissingPlaceholderTextError = (_c: Element | null, id: Matcher) =>
   `Unable to find an element with the placeholder text of: ${id}`;
 
 const [
-  queryByShadowPlaceholderText,
-  getAllByShadowPlaceholderText,
-  getByShadowPlaceholderText,
-  findAllByShadowPlaceholderText,
-  findByShadowPlaceholderText,
+  _queryByShadowPlaceholderText,
+  _getAllByShadowPlaceholderText,
+  _getByShadowPlaceholderText,
+  _findAllByShadowPlaceholderText,
+  _findByShadowPlaceholderText,
 ] = toShadowQueries(
   buildQueries<ScreenShadowSelectorMatcherParams>(
     queryAllByShadowPlaceholderText,
     getMultiplePlaceholderTextError,
-    getMissingPlaceholderTextError
-  )
+    getMissingPlaceholderTextError,
+  ),
 );
+
+const queryByShadowPlaceholderText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _queryByShadowPlaceholderText>
+) => _queryByShadowPlaceholderText(...args) as ReturnType<QueryByText<T>>;
+const getAllByShadowPlaceholderText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getAllByShadowPlaceholderText>
+) => _getAllByShadowPlaceholderText(...args) as Array<ReturnType<GetByText<T>>>;
+const getByShadowPlaceholderText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getByShadowPlaceholderText>
+) => _getByShadowPlaceholderText(...args) as ReturnType<GetByText<T>>;
+const findAllByShadowPlaceholderText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findAllByShadowPlaceholderText>
+) => _findAllByShadowPlaceholderText(...args) as ReturnType<FindAllByText<T>>;
+const findByShadowPlaceholderText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findByShadowPlaceholderText>
+) => _findByShadowPlaceholderText(...args) as ReturnType<FindByText<T>>;
 
 // Text
 function queryAllByShadowText<T extends HTMLElement = HTMLElement>(
   ...args: ShadowSelectorMatcherParams
-): T[] {
+): ReturnType<AllByText<T>> {
   let [container, id, options] = args;
 
   if (options == null) {
@@ -179,8 +242,8 @@ function queryAllByShadowText<T extends HTMLElement = HTMLElement>(
       patchWrap(() =>
         getAllElementsAndShadowRoots(container, options)
           .map((el) => queryAllByText(el as HTMLElement, id, options))
-          .flat(Infinity)
-      )
+          .flat(Infinity),
+      ),
     ),
   ] as T[];
 }
@@ -191,23 +254,39 @@ const getMissingTextError = (_c: Element | null, id: Matcher) =>
   `Unable to find an element with the text of: ${id}`;
 
 const [
-  queryByShadowText,
-  getAllByShadowText,
-  getByShadowText,
-  findAllByShadowText,
-  findByShadowText,
+  _queryByShadowText,
+  _getAllByShadowText,
+  _getByShadowText,
+  _findAllByShadowText,
+  _findByShadowText,
 ] = toShadowQueries(
   buildQueries<ScreenShadowSelectorMatcherParams>(
     queryAllByShadowText,
     getMultipleTextError,
-    getMissingTextError
-  )
+    getMissingTextError,
+  ),
 );
+
+const queryByShadowText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _queryByShadowText>
+) => _queryByShadowText(...args) as ReturnType<QueryByText<T>>;
+const getAllByShadowText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getAllByShadowText>
+) => _getAllByShadowText(...args) as Array<ReturnType<GetByText<T>>>;
+const getByShadowText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getByShadowText>
+) => _getByShadowText(...args) as ReturnType<GetByText<T>>;
+const findAllByShadowText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findAllByShadowText>
+) => _findAllByShadowText(...args) as ReturnType<FindAllByText<T>>;
+const findByShadowText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findByShadowText>
+) => _findByShadowText(...args) as ReturnType<FindByText<T>>;
 
 // Display Value
 function queryAllByShadowDisplayValue<T extends HTMLElement = HTMLElement>(
   ...args: ShadowSelectorMatcherParams
-): T[] {
+): ReturnType<AllByBoundAttribute<T>> {
   let [container, id, options] = args;
 
   if (options == null) {
@@ -221,8 +300,8 @@ function queryAllByShadowDisplayValue<T extends HTMLElement = HTMLElement>(
       patchWrap(() =>
         getAllElementsAndShadowRoots(container, options)
           .map((el) => queryAllByDisplayValue(el as HTMLElement, id, options))
-          .flat(Infinity)
-      )
+          .flat(Infinity),
+      ),
     ),
   ] as T[];
 }
@@ -233,23 +312,46 @@ const getMissingDisplayValueError = (_c: Element | null, id: Matcher) =>
   `Unable to find an element with the display value of: ${id}`;
 
 const [
-  queryByShadowDisplayValue,
-  getAllByShadowDisplayValue,
-  getByShadowDisplayValue,
-  findAllByShadowDisplayValue,
-  findByShadowDisplayValue,
+  _queryByShadowDisplayValue,
+  _getAllByShadowDisplayValue,
+  _getByShadowDisplayValue,
+  _findAllByShadowDisplayValue,
+  _findByShadowDisplayValue,
 ] = toShadowQueries(
   buildQueries<ScreenShadowSelectorMatcherParams>(
     queryAllByShadowDisplayValue,
     getMultipleDisplayValueError,
-    getMissingDisplayValueError
-  )
+    getMissingDisplayValueError,
+  ),
 );
+
+const queryByShadowDisplayValue = <T extends HTMLElement>(
+  ...args: Parameters<typeof _queryByShadowDisplayValue>
+) =>
+  _queryByShadowDisplayValue(...args) as ReturnType<QueryByBoundAttribute<T>>;
+const getAllByShadowDisplayValue = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getAllByShadowDisplayValue>
+) =>
+  _getAllByShadowDisplayValue(...args) as Array<
+    ReturnType<GetByBoundAttribute<T>>
+  >;
+const getByShadowDisplayValue = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getByShadowDisplayValue>
+) => _getByShadowDisplayValue(...args) as ReturnType<GetByBoundAttribute<T>>;
+const findAllByShadowDisplayValue = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findAllByShadowDisplayValue>
+) =>
+  _findAllByShadowDisplayValue(...args) as ReturnType<
+    FindAllByBoundAttribute<T>
+  >;
+const findByShadowDisplayValue = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findByShadowDisplayValue>
+) => _findByShadowDisplayValue(...args) as ReturnType<FindByBoundAttribute<T>>;
 
 // Alt Text
 function queryAllByShadowAltText<T extends HTMLElement = HTMLElement>(
   ...args: ShadowMatcherParams
-): T[] {
+): ReturnType<AllByText<T>> {
   let [container, id, options] = args;
 
   if (options == null) {
@@ -263,8 +365,8 @@ function queryAllByShadowAltText<T extends HTMLElement = HTMLElement>(
       patchWrap(() =>
         getAllElementsAndShadowRoots(container, options)
           .map((el) => queryAllByAltText(el as HTMLElement, id, options))
-          .flat(Infinity)
-      )
+          .flat(Infinity),
+      ),
     ),
   ] as T[];
 }
@@ -275,23 +377,39 @@ const getMissingAltTextError = (_c: Element | null, id: Matcher) =>
   `Unable to find an element with the alt text of: ${id}`;
 
 const [
-  queryByShadowAltText,
-  getAllByShadowAltText,
-  getByShadowAltText,
-  findAllByShadowAltText,
-  findByShadowAltText,
+  _queryByShadowAltText,
+  _getAllByShadowAltText,
+  _getByShadowAltText,
+  _findAllByShadowAltText,
+  _findByShadowAltText,
 ] = toShadowQueries(
   buildQueries<ScreenShadowMatcherParams>(
     queryAllByShadowAltText,
     getMultipleAltTextError,
-    getMissingAltTextError
-  )
+    getMissingAltTextError,
+  ),
 );
+
+const queryByShadowAltText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _queryByShadowAltText>
+) => _queryByShadowAltText(...args) as ReturnType<QueryByText<T>>;
+const getAllByShadowAltText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getAllByShadowAltText>
+) => _getAllByShadowAltText(...args) as Array<ReturnType<GetByText<T>>>;
+const getByShadowAltText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getByShadowAltText>
+) => _getByShadowAltText(...args) as ReturnType<GetByText<T>>;
+const findAllByShadowAltText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findAllByShadowAltText>
+) => _findAllByShadowAltText(...args) as ReturnType<FindAllByText<T>>;
+const findByShadowAltText = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findByShadowAltText>
+) => _findByShadowAltText(...args) as ReturnType<FindByText<T>>;
 
 // Title
 function queryAllByShadowTitle<T extends HTMLElement = HTMLElement>(
   ...args: ShadowMatcherParams
-): T[] {
+): ReturnType<AllByBoundAttribute<T>> {
   let [container, id, options] = args;
 
   if (options == null) {
@@ -305,8 +423,8 @@ function queryAllByShadowTitle<T extends HTMLElement = HTMLElement>(
       patchWrap(() =>
         getAllElementsAndShadowRoots(container, options)
           .map((el) => queryAllByTitle(el as HTMLElement, id, options))
-          .flat(Infinity)
-      )
+          .flat(Infinity),
+      ),
     ),
   ] as T[];
 }
@@ -317,23 +435,39 @@ const getMissingTitleError = (_c: Element | null, id: Matcher) =>
   `Unable to find an element with the title of: ${id}`;
 
 const [
-  queryByShadowTitle,
-  getAllByShadowTitle,
-  getByShadowTitle,
-  findAllByShadowTitle,
-  findByShadowTitle,
+  _queryByShadowTitle,
+  _getAllByShadowTitle,
+  _getByShadowTitle,
+  _findAllByShadowTitle,
+  _findByShadowTitle,
 ] = toShadowQueries(
   buildQueries<ScreenShadowMatcherParams>(
     queryAllByShadowTitle,
     getMultipleTitleError,
-    getMissingTitleError
-  )
+    getMissingTitleError,
+  ),
 );
+
+const queryByShadowTitle = <T extends HTMLElement>(
+  ...args: Parameters<typeof _queryByShadowTitle>
+) => _queryByShadowTitle(...args) as ReturnType<QueryByBoundAttribute<T>>;
+const getAllByShadowTitle = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getAllByShadowTitle>
+) => _getAllByShadowTitle(...args) as Array<ReturnType<GetByBoundAttribute<T>>>;
+const getByShadowTitle = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getByShadowTitle>
+) => _getByShadowTitle(...args) as ReturnType<GetByBoundAttribute<T>>;
+const findAllByShadowTitle = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findAllByShadowTitle>
+) => _findAllByShadowTitle(...args) as ReturnType<FindAllByBoundAttribute<T>>;
+const findByShadowTitle = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findByShadowTitle>
+) => _findByShadowTitle(...args) as ReturnType<FindByBoundAttribute<T>>;
 
 // Test Id
 function queryAllByShadowTestId<T extends HTMLElement = HTMLElement>(
   ...args: ShadowMatcherParams
-): T[] {
+): ReturnType<AllByBoundAttribute<T>> {
   let [container, id, options] = args;
 
   if (options == null) {
@@ -347,8 +481,8 @@ function queryAllByShadowTestId<T extends HTMLElement = HTMLElement>(
       patchWrap(() =>
         getAllElementsAndShadowRoots(container, options)
           .map((el) => queryAllByTestId(el as HTMLElement, id, options))
-          .flat(Infinity)
-      )
+          .flat(Infinity),
+      ),
     ),
   ] as T[];
 }
@@ -359,18 +493,35 @@ const getMissingTestIdError = (_c: Element | null, id: Matcher) =>
   `Unable to find an element with the test id of: ${id}`;
 
 const [
-  queryByShadowTestId,
-  getAllByShadowTestId,
-  getByShadowTestId,
-  findAllByShadowTestId,
-  findByShadowTestId,
+  _queryByShadowTestId,
+  _getAllByShadowTestId,
+  _getByShadowTestId,
+  _findAllByShadowTestId,
+  _findByShadowTestId,
 ] = toShadowQueries(
   buildQueries<ScreenShadowMatcherParams>(
     queryAllByShadowTestId,
     getMultipleTestIdError,
-    getMissingTestIdError
-  )
+    getMissingTestIdError,
+  ),
 );
+
+const queryByShadowTestId = <T extends HTMLElement>(
+  ...args: Parameters<typeof _queryByShadowTestId>
+) => _queryByShadowTestId(...args) as ReturnType<QueryByBoundAttribute<T>>;
+const getAllByShadowTestId = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getAllByShadowTestId>
+) =>
+  _getAllByShadowTestId(...args) as Array<ReturnType<GetByBoundAttribute<T>>>;
+const getByShadowTestId = <T extends HTMLElement>(
+  ...args: Parameters<typeof _getByShadowTestId>
+) => _getByShadowTestId(...args) as ReturnType<GetByBoundAttribute<T>>;
+const findAllByShadowTestId = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findAllByShadowTestId>
+) => _findAllByShadowTestId(...args) as ReturnType<FindAllByBoundAttribute<T>>;
+const findByShadowTestId = <T extends HTMLElement>(
+  ...args: Parameters<typeof _findByShadowTestId>
+) => _findByShadowTestId(...args) as ReturnType<FindByBoundAttribute<T>>;
 
 export {
   // Role

--- a/src/shadow-screen.ts
+++ b/src/shadow-screen.ts
@@ -16,299 +16,419 @@ const shadowScreen = {
   ...screen,
   debug,
   // Role
-  queryAllByShadowRole: (...args: ScreenShadowRoleMatcherParams) =>
-    shadowQueries.queryAllByShadowRole(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  queryByShadowRole: (...args: ScreenShadowRoleMatcherParams) =>
-    shadowQueries.queryByShadowRole(document.documentElement, args[0], args[1]),
-  getAllByShadowRole: (...args: ScreenShadowRoleMatcherParams) =>
-    shadowQueries.getAllByShadowRole(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getByShadowRole: (...args: ScreenShadowRoleMatcherParams) =>
-    shadowQueries.getByShadowRole(document.documentElement, args[0], args[1]),
-  findAllByShadowRole: (...args: AsyncScreenShadowRoleMatcherParams) =>
-    shadowQueries.findAllByShadowRole(
+  queryAllByShadowRole: <T extends HTMLElement>(
+    ...args: ScreenShadowRoleMatcherParams
+  ) =>
+    shadowQueries.queryAllByShadowRole<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
     ),
-  findByShadowRole: (...args: AsyncScreenShadowRoleMatcherParams) =>
-    shadowQueries.findByShadowRole(
+  queryByShadowRole: <T extends HTMLElement>(
+    ...args: ScreenShadowRoleMatcherParams
+  ) =>
+    shadowQueries.queryByShadowRole<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
+    ),
+  getAllByShadowRole: <T extends HTMLElement>(
+    ...args: ScreenShadowRoleMatcherParams
+  ) =>
+    shadowQueries.getAllByShadowRole<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  getByShadowRole: <T extends HTMLElement>(
+    ...args: ScreenShadowRoleMatcherParams
+  ) =>
+    shadowQueries.getByShadowRole<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  findAllByShadowRole: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowRoleMatcherParams
+  ) =>
+    shadowQueries.findAllByShadowRole<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
+    ),
+  findByShadowRole: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowRoleMatcherParams
+  ) =>
+    shadowQueries.findByShadowRole<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
     ),
 
   // Label Text
-  queryAllByShadowLabelText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.queryAllByShadowLabelText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  queryByShadowLabelText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.queryByShadowLabelText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getAllByShadowLabelText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.getAllByShadowLabelText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getByShadowLabelText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.getByShadowLabelText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  findAllByShadowLabelText: (...args: AsyncScreenShadowSelectorMatcherParams) =>
-    shadowQueries.findAllByShadowLabelText(
+  queryAllByShadowLabelText: <T extends HTMLElement>(
+    ...args: ScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.queryAllByShadowLabelText<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
     ),
-  findByShadowLabelText: (...args: AsyncScreenShadowSelectorMatcherParams) =>
-    shadowQueries.findByShadowLabelText(
+  queryByShadowLabelText: <T extends HTMLElement>(
+    ...args: ScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.queryByShadowLabelText<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
+    ),
+  getAllByShadowLabelText: <T extends HTMLElement>(
+    ...args: ScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.getAllByShadowLabelText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  getByShadowLabelText: <T extends HTMLElement>(
+    ...args: ScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.getByShadowLabelText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  findAllByShadowLabelText: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.findAllByShadowLabelText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
+    ),
+  findByShadowLabelText: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.findByShadowLabelText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
     ),
 
   // Placeholder Text
-  queryAllByShadowPlaceholderText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowPlaceholderText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  queryByShadowPlaceholderText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowPlaceholderText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getAllByShadowPlaceholderText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowPlaceholderText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getByShadowPlaceholderText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getByShadowPlaceholderText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  findAllByShadowPlaceholderText: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findAllByShadowPlaceholderText(
+  queryAllByShadowPlaceholderText: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryAllByShadowPlaceholderText<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
     ),
-  findByShadowPlaceholderText: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findByShadowPlaceholderText(
+  queryByShadowPlaceholderText: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryByShadowPlaceholderText<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
+    ),
+  getAllByShadowPlaceholderText: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getAllByShadowPlaceholderText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  getByShadowPlaceholderText: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getByShadowPlaceholderText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  findAllByShadowPlaceholderText: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findAllByShadowPlaceholderText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
+    ),
+  findByShadowPlaceholderText: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findByShadowPlaceholderText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
     ),
 
   // Text
-  queryAllByShadowText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.queryAllByShadowText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  queryByShadowText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.queryByShadowText(document.documentElement, args[0], args[1]),
-  getAllByShadowText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.getAllByShadowText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getByShadowText: (...args: ScreenShadowSelectorMatcherParams) =>
-    shadowQueries.getByShadowText(document.documentElement, args[0], args[1]),
-  findAllByShadowText: (...args: AsyncScreenShadowSelectorMatcherParams) =>
-    shadowQueries.findAllByShadowText(
+  queryAllByShadowText: <T extends HTMLElement>(
+    ...args: ScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.queryAllByShadowText<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
     ),
-  findByShadowText: (...args: AsyncScreenShadowSelectorMatcherParams) =>
-    shadowQueries.findByShadowText(
+  queryByShadowText: <T extends HTMLElement>(
+    ...args: ScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.queryByShadowText<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
+    ),
+  getAllByShadowText: <T extends HTMLElement>(
+    ...args: ScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.getAllByShadowText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  getByShadowText: <T extends HTMLElement>(
+    ...args: ScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.getByShadowText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  findAllByShadowText: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.findAllByShadowText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
+    ),
+  findByShadowText: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowSelectorMatcherParams
+  ) =>
+    shadowQueries.findByShadowText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
     ),
 
   // Display Value
-  queryAllByShadowDisplayValue: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowDisplayValue(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  queryByShadowDisplayValue: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowDisplayValue(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getAllByShadowDisplayValue: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowDisplayValue(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getByShadowDisplayValue: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getByShadowDisplayValue(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  findAllByShadowDisplayValue: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findAllByShadowDisplayValue(
+  queryAllByShadowDisplayValue: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryAllByShadowDisplayValue<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
     ),
-  findByShadowDisplayValue: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findByShadowDisplayValue(
+  queryByShadowDisplayValue: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryByShadowDisplayValue<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
+    ),
+  getAllByShadowDisplayValue: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getAllByShadowDisplayValue<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  getByShadowDisplayValue: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getByShadowDisplayValue<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  findAllByShadowDisplayValue: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findAllByShadowDisplayValue<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
+    ),
+  findByShadowDisplayValue: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findByShadowDisplayValue<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
     ),
 
   // Alt Text
-  queryAllByShadowAltText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowAltText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  queryByShadowAltText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowAltText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getAllByShadowAltText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowAltText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getByShadowAltText: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getByShadowAltText(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  findAllByShadowAltText: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findAllByShadowAltText(
+  queryAllByShadowAltText: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryAllByShadowAltText<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
     ),
-  findByShadowAltText: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findByShadowAltText(
+  queryByShadowAltText: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryByShadowAltText<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
+    ),
+  getAllByShadowAltText: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getAllByShadowAltText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  getByShadowAltText: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getByShadowAltText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  findAllByShadowAltText: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findAllByShadowAltText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
+    ),
+  findByShadowAltText: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findByShadowAltText<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
     ),
 
   // Title
-  queryAllByShadowTitle: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowTitle(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  queryByShadowTitle: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowTitle(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getAllByShadowTitle: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowTitle(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getByShadowTitle: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getByShadowTitle(document.documentElement, args[0], args[1]),
-  findAllByShadowTitle: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findAllByShadowTitle(
+  queryAllByShadowTitle: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryAllByShadowTitle<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
     ),
-  findByShadowTitle: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findByShadowTitle(
+  queryByShadowTitle: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryByShadowTitle<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
+    ),
+  getAllByShadowTitle: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getAllByShadowTitle<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  getByShadowTitle: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getByShadowTitle<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  findAllByShadowTitle: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findAllByShadowTitle<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
+    ),
+  findByShadowTitle: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findByShadowTitle<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
     ),
 
   // Test Id
-  queryAllByShadowTestId: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryAllByShadowTestId(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  queryByShadowTestId: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.queryByShadowTestId(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getAllByShadowTestId: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getAllByShadowTestId(
-      document.documentElement,
-      args[0],
-      args[1]
-    ),
-  getByShadowTestId: (...args: ScreenShadowMatcherParams) =>
-    shadowQueries.getByShadowTestId(document.documentElement, args[0], args[1]),
-  findAllByShadowTestId: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findAllByShadowTestId(
+  queryAllByShadowTestId: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryAllByShadowTestId<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
     ),
-  findByShadowTestId: (...args: AsyncScreenShadowMatcherParams) =>
-    shadowQueries.findByShadowTestId(
+  queryByShadowTestId: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.queryByShadowTestId<T>(
       document.documentElement,
       args[0],
       args[1],
-      args[2]
+    ),
+  getAllByShadowTestId: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getAllByShadowTestId<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  getByShadowTestId: <T extends HTMLElement>(
+    ...args: ScreenShadowMatcherParams
+  ) =>
+    shadowQueries.getByShadowTestId<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+    ),
+  findAllByShadowTestId: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findAllByShadowTestId<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
+    ),
+  findByShadowTestId: <T extends HTMLElement>(
+    ...args: AsyncScreenShadowMatcherParams
+  ) =>
+    shadowQueries.findByShadowTestId<T>(
+      document.documentElement,
+      args[0],
+      args[1],
+      args[2],
     ),
 };
 

--- a/src/trick-dom-testing-library.ts
+++ b/src/trick-dom-testing-library.ts
@@ -27,7 +27,7 @@ function removeDOMPatch() {
 }
 
 export function patchWrap<T extends (...args: any) => any>(
-  callback: T
+  callback: T,
 ): ReturnType<T> {
   patchDOM();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,56 +22,56 @@ export interface ShadowSelectorMatcherOptions
 // For queryBy / getBy queries
 export type ShadowRoleMatcherParams = [
   container: HTMLElement,
-  ...args: ScreenShadowRoleMatcherParams
+  ...args: ScreenShadowRoleMatcherParams,
 ];
 export type ShadowSelectorMatcherParams = [
   container: HTMLElement,
-  ...args: ScreenShadowSelectorMatcherParams
+  ...args: ScreenShadowSelectorMatcherParams,
 ];
 export type ShadowMatcherParams = [
   container: HTMLElement,
-  ...args: ScreenShadowMatcherParams
+  ...args: ScreenShadowMatcherParams,
 ];
 
 export type ScreenShadowRoleMatcherParams = [
   role: ByRoleMatcher,
-  options?: ShadowByRoleOptions | undefined
+  options?: ShadowByRoleOptions | undefined,
 ];
 export type ScreenShadowSelectorMatcherParams = [
   id: Matcher,
-  options?: ShadowSelectorMatcherOptions | undefined
+  options?: ShadowSelectorMatcherOptions | undefined,
 ];
 export type ScreenShadowMatcherParams = [
   id: Matcher,
-  options?: ShadowMatcherOptions | undefined
+  options?: ShadowMatcherOptions | undefined,
 ];
 
 // For findBy queries
 export type AsyncShadowRoleMatcherParams = [
   container: HTMLElement,
-  ...args: AsyncScreenShadowRoleMatcherParams
+  ...args: AsyncScreenShadowRoleMatcherParams,
 ];
 export type AsyncShadowSelectorMatcherParams = [
   container: HTMLElement,
-  ...args: AsyncScreenShadowSelectorMatcherParams
+  ...args: AsyncScreenShadowSelectorMatcherParams,
 ];
 export type AsyncShadowMatcherParams = [
   container: HTMLElement,
-  ...args: AsyncScreenShadowMatcherParams
+  ...args: AsyncScreenShadowMatcherParams,
 ];
 
 export type AsyncScreenShadowRoleMatcherParams = [
   role: ByRoleMatcher,
   options?: ShadowByRoleOptions | undefined,
-  waitForOptions?: waitForOptions | undefined
+  waitForOptions?: waitForOptions | undefined,
 ];
 export type AsyncScreenShadowSelectorMatcherParams = [
   id: Matcher,
   options?: ShadowSelectorMatcherOptions | undefined,
-  waitForOptions?: waitForOptions | undefined
+  waitForOptions?: waitForOptions | undefined,
 ];
 export type AsyncScreenShadowMatcherParams = [
   id: Matcher,
   options?: ShadowMatcherOptions | undefined,
-  waitForOptions?: waitForOptions | undefined
+  waitForOptions?: waitForOptions | undefined,
 ];


### PR DESCRIPTION
Add generics to shadow queries to align with Testing-Library's base functions.

Fixes #52 