### PR TITLE
fix slotted child nodeS

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ import { screen, getByShadowRole } from "shadow-dom-testing-library"
 
 test("Lets test some rendering", () => {
   render(<Button />)
-  getByShadowRole(document, "button", { shallow: true })
-  await screen.findByShadowLabelText(/Car Manufacturer/i, { shallow: true })
-  screen.queryAllByShadowTitle("delete", { shallow: true })
+  getByShadowRole(document, "button", { depth: 1 })
+  await screen.findByShadowLabelText(/Car Manufacturer/i, { depth: 1 })
+  screen.queryAllByShadowTitle("delete", { depth: 1 })
 })
 ```
 
@@ -117,7 +117,7 @@ import {
 } from "shadow-dom-testing-library";
 
 const elements = deepQuerySelectorAll(document, "my-button");
-const element = deepQuerySelector(document, "my-button", { shallow: true });
+const element = deepQuerySelector(document, "my-button", { depth: 1 });
 ```
 
 A `within` function is exported to provide the `<ByShadow>` queries

--- a/__tests__/deep-query-selectors.test.tsx
+++ b/__tests__/deep-query-selectors.test.tsx
@@ -37,9 +37,9 @@ describe("deepQuerySelector()", () => {
 
   test("Should not find and 3rd level button element when shallow is true", () => {
     const { container, baseElement } = render(<TripleShadowRoots />);
-    let el = deepQuerySelector(container, "button", { shallow: true });
+    let el = deepQuerySelector(container, "button", { depth: 1 });
     expect(el).not.toBeInstanceOf(HTMLButtonElement);
-    el = deepQuerySelector(baseElement, "button", { shallow: true });
+    el = deepQuerySelector(baseElement, "button", { depth: 1 });
     expect(el).not.toBeInstanceOf(HTMLButtonElement);
   });
 });

--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -53,7 +53,9 @@ test("Should test shadow roots of passing in element", async () => {
     "[36m<my-button>[39m
       [36m<ShadowRoot>[39m
         [36m<button>[39m
-          [36m<slot />[39m
+          [36m<slot>[39m
+            [0m0[0m
+          [36m</slot>[39m
         [36m</button>[39m
       [36m</ShadowRoot>[39m
       [0m0[0m
@@ -76,7 +78,9 @@ test("Should render body if passed in", () => {
         [36m<my-button>[39m
           [36m<ShadowRoot>[39m
             [36m<button>[39m
-              [36m<slot />[39m
+              [36m<slot>[39m
+                [0m0[0m
+              [36m</slot>[39m
             [36m</button>[39m
           [36m</ShadowRoot>[39m
           [0m0[0m
@@ -101,7 +105,9 @@ test("Should render HTML tag if passed in", () => {
         [36m<my-button>[39m
           [36m<ShadowRoot>[39m
             [36m<button>[39m
-              [36m<slot />[39m
+              [36m<slot>[39m
+                [0m0[0m
+              [36m</slot>[39m
             [36m</button>[39m
           [36m</ShadowRoot>[39m
           [0m0[0m
@@ -143,7 +149,8 @@ test("It should render 3 shadow root instances", () => {
                     [36m/>[39m[0m
                   [36m</ShadowRoot>[39m
                 [36m</duplicate-buttons>[39m[0m
-                [36m<slot />[39m[0m
+                [36m<slot>[39m[0m
+                [36m</slot>[39m[0m
               [36m</ShadowRoot>[39m[0m
             [36m</nested-shadow-roots>[39m[0m
           [36m</ShadowRoot>[39m

--- a/__tests__/shadowLabelText.test.tsx
+++ b/__tests__/shadowLabelText.test.tsx
@@ -46,4 +46,56 @@ describe("ByShadowLabelText()", () => {
     const getLabels = screen.getAllByShadowLabelText("Comments");
     expect(getLabels.length).toBeGreaterThan(0);
   });
+
+  it("should work with all queries when used with a slotted label", async () => {
+    const { container } = render(
+      <TextArea>
+        <div slot="label">Slotted Label Text</div>
+      </TextArea>,
+    );
+
+    const findContainerLabel = await findByShadowLabelText(
+      container,
+      /lotted Label Text/,
+      { exact: false },
+    );
+    expect(findContainerLabel).toBeInTheDocument();
+    const findContainerLabels =
+      await screen.findAllByShadowLabelText("Slotted Label Text");
+    expect(findContainerLabels.length).toBeGreaterThan(0);
+
+    const queryContainerLabel =
+      screen.queryByShadowLabelText("Slotted Label Text");
+    expect(queryContainerLabel).toBeInTheDocument();
+    const queryContainerLabels =
+      screen.queryAllByShadowLabelText("Slotted Label Text");
+    expect(queryContainerLabels.length).toBeGreaterThan(0);
+
+    const getContainerLabel = screen.getByShadowLabelText("Slotted Label Text");
+    expect(getContainerLabel).toBeInTheDocument();
+    const getContainerLabels =
+      screen.getAllByShadowLabelText("Slotted Label Text");
+    expect(getContainerLabels.length).toBeGreaterThan(0);
+
+    // // Use await findByX to let things render then use other calls.
+    const findLabel = await screen.findByShadowLabelText("Slotted Label Text");
+    expect(findLabel).toBeInTheDocument();
+    const findLabels = await screen.findAllByShadowLabelText(
+      /otted label tex/i,
+      {
+        exact: false,
+      },
+    );
+    expect(findLabels.length).toBeGreaterThan(0);
+
+    const queryLabel = screen.queryByShadowLabelText("Slotted Label Text");
+    expect(queryLabel).toBeInTheDocument();
+    const queryLabels = screen.queryAllByShadowLabelText("Slotted Label Text");
+    expect(queryLabels.length).toBeGreaterThan(0);
+
+    const getLabel = screen.getByShadowLabelText("Slotted Label Text");
+    expect(getLabel).toBeInTheDocument();
+    const getLabels = screen.getAllByShadowLabelText("Slotted Label Text");
+    expect(getLabels.length).toBeGreaterThan(0);
+  });
 });

--- a/components.tsx
+++ b/components.tsx
@@ -32,7 +32,7 @@ class MyTextArea extends HTMLElement {
 		if (this.shadowRoot == null) return ""
 
     this.shadowRoot.innerHTML = `
-			<label for="textarea">${this.label}</label>
+			<label for="textarea"><slot name="label">${this.label}</slot></label>
 
 			<textarea id="textarea"><slot></slot></textarea>
 		`;
@@ -222,7 +222,7 @@ export function Button() {
 }
 
 
-export const TextArea = () => <my-text-area label="Comments" />
+export const TextArea = (props: any) => <my-text-area label="Comments">{props.children}</my-text-area>
 
 export const AnimatedImage = () => (
   <my-image

--- a/src/deep-query-selectors.ts
+++ b/src/deep-query-selectors.ts
@@ -2,9 +2,9 @@ import { patchWrap } from "./trick-dom-testing-library";
 import { Container, ShadowOptions } from "./types";
 
 function fixOptions(options: ShadowOptions) {
-  if (options.shallow != null) {
+  if (options.shallow === true && options.depth !== 1) {
     console.warn(
-      `The "shallow" option will be removed in the next major release. Please use "{depth: 1}" to maintain the same functionality.`,
+      `The "shallow" option will be removed in the next major release. Please use "{depth: 1}" to maintain the same functionality as {shallow: true}.`,
     );
 
     if (options.shallow === true) {
@@ -52,10 +52,11 @@ export function deepQuerySelectorAll<T extends HTMLElement>(
   selector: string,
   options: ShadowOptions = { shallow: false, depth: Infinity },
 ): T[] {
-  options = fixOptions(options);
-
   return patchWrap(() => {
-    const elements = getAllElementsAndShadowRoots(container, options);
+    const elements = getAllElementsAndShadowRoots(
+      container,
+      fixOptions(options),
+    );
 
     const queriedElements = elements
       .map((el) => Array.from(el.querySelectorAll<T>(selector)))
@@ -70,10 +71,9 @@ export function getAllElementsAndShadowRoots(
   container: Container,
   options: ShadowOptions = { shallow: false, depth: Infinity },
 ) {
-  options = fixOptions(options);
   const selector = "*";
 
-  return recurse(container, selector, options);
+  return recurse(container, selector, fixOptions(options));
 }
 
 function recurse(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { logShadowDOM } from "./log-shadow-dom";
 import { prettyShadowDOM } from "./pretty-shadow-dom";
 import { shadowScreen } from "./shadow-screen";
 import { shadowWithin } from "./shadow-within";
+import { logRoles } from "./log-roles";
 
 configure({
   // https://github.com/testing-library/dom-testing-library/blob/39a64d4b862f706d09f0cd225ce9eda892f1e8d8/src/config.ts#L36-L51
@@ -44,4 +45,5 @@ export {
   debug,
   logShadowDOM,
   prettyShadowDOM,
+  logRoles,
 };

--- a/src/log-roles.ts
+++ b/src/log-roles.ts
@@ -1,0 +1,109 @@
+import { getConfig, isInaccessible } from "@testing-library/dom";
+import {
+  getImplicitAriaRoles,
+  // @ts-expect-error
+} from "@testing-library/dom/dist/role-helpers";
+
+import {
+  computeAccessibleName,
+  computeAccessibleDescription,
+} from "dom-accessibility-api";
+import { prettyShadowDOM } from "./pretty-shadow-dom";
+
+function getRoles(container: Element, { hidden = false } = {}) {
+  function getShadowChildren(node: Element, shadowChildren: Element[] = []) {
+    if (!node.shadowRoot) {
+      return shadowChildren;
+    }
+
+    // should we push the shadowRoot??
+    // shadowChildren.push(node.shadowRoot)
+
+    for (const child of Array.from(node.shadowRoot.children)) {
+      getShadowChildren(child, shadowChildren);
+      shadowChildren.push(child);
+    }
+
+    return shadowChildren;
+  }
+  function flattenDOM(node: Element): Element[] {
+    const children = Array.from(node.children);
+    const flatChildren = [...getShadowChildren(node), ...children].reduce<
+      Element[]
+    >((acc, child) => [...acc, ...flattenDOM(child)], []);
+    return [node, ...flatChildren];
+  }
+
+  return flattenDOM(container)
+    .filter((element) => {
+      return hidden === false
+        ? isInaccessible(element as Element) === false
+        : true;
+    })
+    .reduce(
+      (acc, node) => {
+        let roles: string[] = [];
+        // TODO: This violates html-aria which does not allow any role on every element
+        if (node.hasAttribute("role")) {
+          roles = node.getAttribute("role")!.split(" ").slice(0, 1);
+        } else {
+          roles = getImplicitAriaRoles(node);
+        }
+
+        return roles.reduce<any>(
+          (rolesAcc, role) =>
+            Array.isArray(rolesAcc[role])
+              ? { ...rolesAcc, [role]: [...rolesAcc[role], node] }
+              : { ...rolesAcc, [role]: [node] },
+          acc,
+        );
+      },
+      {} as Record<string, Element[]>,
+    );
+}
+
+function prettyRoles(
+  dom: Element,
+  {
+    hidden,
+    includeDescription,
+  }: { hidden?: boolean; includeDescription?: boolean },
+) {
+  const roles = getRoles(dom, { hidden });
+  // We prefer to skip generic role, we don't recommend it
+  return Object.entries(roles)
+    .filter(([role]) => role !== "generic")
+    .map(([role, elements]) => {
+      const delimiterBar = "-".repeat(50);
+      const elementsString = elements
+        .map((el) => {
+          const nameString = `Name "${computeAccessibleName(el, {
+            computedStyleSupportsPseudoElements:
+              getConfig().computedStyleSupportsPseudoElements,
+          })}":\n`;
+
+          // @ts-expect-error
+          const domString = prettyShadowDOM(el.cloneNode(false));
+
+          if (includeDescription) {
+            const descriptionString = `Description "${computeAccessibleDescription(
+              el,
+              {
+                computedStyleSupportsPseudoElements:
+                  getConfig().computedStyleSupportsPseudoElements,
+              },
+            )}":\n`;
+            return `${nameString}${descriptionString}${domString}`;
+          }
+
+          return `${nameString}${domString}`;
+        })
+        .join("\n\n");
+
+      return `${role}:\n\n${elementsString}\n\n${delimiterBar}`;
+    })
+    .join("\n");
+}
+
+export const logRoles = (dom: Element, { hidden = false } = {}) =>
+  console.log(prettyRoles(dom, { hidden }));

--- a/src/log-roles.ts
+++ b/src/log-roles.ts
@@ -1,8 +1,5 @@
 import { getConfig, isInaccessible } from "@testing-library/dom";
-import {
-  getImplicitAriaRoles,
-  // @ts-expect-error
-} from "@testing-library/dom/dist/role-helpers";
+import { getImplicitAriaRoles } from "@testing-library/dom/dist/role-helpers";
 
 import {
   computeAccessibleName,

--- a/src/testing-library.d.ts
+++ b/src/testing-library.d.ts
@@ -1,0 +1,3 @@
+declare module "@testing-library/dom/dist/role-helpers" {
+  export function getImplicitAriaRoles(node: Node): string[];
+}

--- a/src/trick-dom-testing-library.ts
+++ b/src/trick-dom-testing-library.ts
@@ -43,7 +43,7 @@ export function patchWrap<T extends (...args: any) => any>(
       "finally" in val &&
       typeof val.finally === "function"
     ) {
-      val.finally(() => removeDOMPatch());
+      val.finally(() => removeDOMPatch(patchRemovalFunctions));
     }
 
     return val;

--- a/src/trick-dom-testing-library.ts
+++ b/src/trick-dom-testing-library.ts
@@ -18,18 +18,20 @@ patchShadowRoot();
 // https://github.com/testing-library/dom-testing-library/blob/73a5694529dbfff289f3d7a01470c45ef5c77715/src/queries/text.ts#L34-L36
 // https://github.com/testing-library/dom-testing-library/blob/73a5694529dbfff289f3d7a01470c45ef5c77715/src/pretty-dom.js#L50-L54
 export function patchDOM() {
-  patchSlotElement();
+  // Return "dispose" callbacks to cleanup patchs
+  return [patchSlotElement()];
 }
 
-function removeDOMPatch() {
-  HTMLSlotElement.prototype.querySelectorAll =
-    HTMLElement.prototype.querySelectorAll;
+function removeDOMPatch(patchRemovalFunctions: Function[]) {
+  for (const fn of patchRemovalFunctions) {
+    fn();
+  }
 }
 
 export function patchWrap<T extends (...args: any) => any>(
   callback: T,
 ): ReturnType<T> {
-  patchDOM();
+  const patchRemovalFunctions = patchDOM();
 
   try {
     const val = callback();
@@ -46,7 +48,7 @@ export function patchWrap<T extends (...args: any) => any>(
 
     return val;
   } finally {
-    removeDOMPatch();
+    removeDOMPatch(patchRemovalFunctions);
   }
 }
 
@@ -81,8 +83,34 @@ function patchShadowRoot() {
 }
 
 function patchSlotElement() {
+  const qsa = HTMLElement.prototype.querySelectorAll;
+  const originalChildNodesDescriptor = Object.getOwnPropertyDescriptor(
+    Node.prototype,
+    "childNodes",
+  );
+  const originalChildNodesGetter = originalChildNodesDescriptor!.get;
+
+  /**
+   * This patch allows labels to get proper textContent, and most likely other text helpers by taking either the projected nodes, or the fallback nodes.
+   * https://github.com/KonnorRogers/shadow-dom-testing-library/issues/64#issuecomment-3177493042
+   * https://github.com/testing-library/dom-testing-library/blob/225a3e4cfaa8f8046989d51b9051df507354b644/src/label-helpers.ts#L13-L35
+   */
+  Object.defineProperty(HTMLSlotElement.prototype, "childNodes", {
+    get() {
+      const projectedNodes: Node[] = this.assignedNodes({ flatten: true });
+
+      // Slotted elements, use those.
+      if (projectedNodes.length > 0) {
+        return projectedNodes;
+      }
+      // if no assignedNodes, return original `childNodes`.
+      return originalChildNodesGetter!.call(this);
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
   HTMLSlotElement.prototype.querySelectorAll = function (str: string) {
-    const qsa = HTMLElement.prototype.querySelectorAll;
     let els: Element[] = [];
 
     this.assignedElements({ flatten: true }).forEach((_el) => {
@@ -109,5 +137,18 @@ function patchSlotElement() {
     return [...new Set(els)] as unknown as ReturnType<
       typeof HTMLSlotElement.prototype.querySelectorAll
     >;
+  };
+
+  return () => {
+    HTMLSlotElement.prototype.querySelectorAll = qsa;
+
+    // There's no way to `delete` a newly defined property, so we just call the original descriptor.
+    Object.defineProperty(HTMLSlotElement.prototype, "childNodes", {
+      get() {
+        return originalChildNodesGetter!.call(this);
+      },
+      enumerable: true,
+      configurable: true,
+    });
   };
 }


### PR DESCRIPTION
Fixes #64 

Fixes #61 

Adds `logRoles` top level function, and adds supported for detected slotted child nodes on `<slot>` elements. 