### PR TITLE
fix: remove erroneous duplicate child nodes when checking "projected" nodes

### DIFF
--- a/__tests__/pretty-shadow-dom.test.tsx
+++ b/__tests__/pretty-shadow-dom.test.tsx
@@ -53,9 +53,7 @@ test("Should test shadow roots of passing in element", async () => {
     "[36m<my-button>[39m
       [36m<ShadowRoot>[39m
         [36m<button>[39m
-          [36m<slot>[39m
-            [0m0[0m
-          [36m</slot>[39m
+          [36m<slot />[39m
         [36m</button>[39m
       [36m</ShadowRoot>[39m
       [0m0[0m
@@ -78,9 +76,7 @@ test("Should render body if passed in", () => {
         [36m<my-button>[39m
           [36m<ShadowRoot>[39m
             [36m<button>[39m
-              [36m<slot>[39m
-                [0m0[0m
-              [36m</slot>[39m
+              [36m<slot />[39m
             [36m</button>[39m
           [36m</ShadowRoot>[39m
           [0m0[0m
@@ -105,9 +101,7 @@ test("Should render HTML tag if passed in", () => {
         [36m<my-button>[39m
           [36m<ShadowRoot>[39m
             [36m<button>[39m
-              [36m<slot>[39m
-                [0m0[0m
-              [36m</slot>[39m
+              [36m<slot />[39m
             [36m</button>[39m
           [36m</ShadowRoot>[39m
           [0m0[0m
@@ -149,8 +143,7 @@ test("It should render 3 shadow root instances", () => {
                     [36m/>[39m[0m
                   [36m</ShadowRoot>[39m
                 [36m</duplicate-buttons>[39m[0m
-                [36m<slot>[39m[0m
-                [36m</slot>[39m[0m
+                [36m<slot />[39m[0m
               [36m</ShadowRoot>[39m[0m
             [36m</nested-shadow-roots>[39m[0m
           [36m</ShadowRoot>[39m

--- a/__tests__/shadowText.test.tsx
+++ b/__tests__/shadowText.test.tsx
@@ -3,7 +3,7 @@ import { findByShadowText, screen } from "../src/index";
 import { html, fixture, nextFrame, aTimeout } from "@open-wc/testing-helpers";
 
 // Will define <my-button>
-import "../components"
+import "../components";
 
 export class ShadowText extends HTMLElement {
   constructor() {
@@ -64,11 +64,11 @@ describe("ShadowText()", () => {
   it("Should not detect the same nodes twice", async () => {
     const el = (await fixture(html`
       <my-button>Click Me</my-button>
-    `) as HTMLElement)
-    await aTimeout(1)
+    `)) as HTMLElement;
+    await aTimeout(1);
 
-    const els = await screen.findAllByShadowText("Click Me")
+    const els = await screen.findAllByShadowText("Click Me");
 
-    expect(els.length).toEqual(1)
-  })
+    expect(els.length).toEqual(1);
+  });
 });

--- a/__tests__/shadowText.test.tsx
+++ b/__tests__/shadowText.test.tsx
@@ -1,6 +1,9 @@
 import { configure, findByText } from "@testing-library/dom";
 import { findByShadowText, screen } from "../src/index";
-import { html, fixture, nextFrame } from "@open-wc/testing-helpers";
+import { html, fixture, nextFrame, aTimeout } from "@open-wc/testing-helpers";
+
+// Will define <my-button>
+import "../components"
 
 export class ShadowText extends HTMLElement {
   constructor() {
@@ -57,4 +60,15 @@ describe("ShadowText()", () => {
     await screen.findByShadowText("Hi there");
     screen.getByShadowText("Hi there");
   });
+
+  it("Should not detect the same nodes twice", async () => {
+    const el = (await fixture(html`
+      <my-button>Click Me</my-button>
+    `) as HTMLElement)
+    await aTimeout(1)
+
+    const els = await screen.findAllByShadowText("Click Me")
+
+    expect(els.length).toEqual(1)
+  })
 });

--- a/components.tsx
+++ b/components.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 /* Web Components */
-class MyButton extends HTMLElement {
+export class MyButton extends HTMLElement {
 	connectedCallback () {
     const shadow = this.attachShadow({mode: 'open'});
     shadow.innerHTML = `<button><slot></slot></button>`;


### PR DESCRIPTION
- Instead of always returning projected children, slots are now "smart" and there is a running WeakMap of any time `childNodes` are accessed on an element by a query so we know if the projected node has already been accounted for.

Fixes #66 