### PR TITLE
feat: allow library configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ const btn = shadowQueries.getByShadowRole<HTMLButtonElement>("button");
 By default, Shadow DOM Testing Library will override your dom-testing-library configuration's `getElementError`. If you would like to change this, you can import the `configure` function and supply your own `getElementError`.
 
 ```ts
-import { configure } from "shadow-dom-testing-library"
+import { configure } from "shadow-dom-testing-library";
 configure({
-  getElementError: (message, container) => {}
-})
+  getElementError: (message, container) => {},
+});
 ```

--- a/README.md
+++ b/README.md
@@ -289,3 +289,14 @@ import { screen, shadowQueries } from "shadow-dom-testing-library";
 const btn = await screen.findByShadowRole<HTMLButtonElement>("button");
 const btn = shadowQueries.getByShadowRole<HTMLButtonElement>("button");
 ```
+
+## Configuration
+
+By default, Shadow DOM Testing Library will override your dom-testing-library configuration's `getElementError`. If you would like to change this, you can import the `configure` function and supply your own `getElementError`.
+
+```ts
+import { configure } from "shadow-dom-testing-library"
+configure({
+  getElementError: (message, container) => {}
+})
+```

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - jest-preview

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { shadowScreen } from "./shadow-screen";
 import { shadowWithin } from "./shadow-within";
 import { logRoles } from "./log-roles";
 
-export function getElementError(...params: Parameters<typeof config["getElementError"]>) {
+export function getElementError(...params: Parameters<ReturnType<typeof getConfig>["getElementError"]>) {
   const [message, container] = params
   const prettifiedDOM = prettyShadowDOM(container);
   const error = new Error(
@@ -24,8 +24,6 @@ export function getElementError(...params: Parameters<typeof config["getElementE
   error.name = "ShadowDOMTestingLibraryElementError";
   return error;
 }
-
-const config = getConfig()
 
 // side-effectful configure. Assume people want to use our getElementError, but export getConfig / configure in case of mismatched dependencies or similar. Easy hook to allow configuring.
 configure({

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,15 @@ import { shadowScreen } from "./shadow-screen";
 import { shadowWithin } from "./shadow-within";
 import { logRoles } from "./log-roles";
 
-export function getElementError(...params: Parameters<ReturnType<typeof getConfig>["getElementError"]>) {
-  const [message, container] = params
+export function getElementError(
+  ...params: Parameters<ReturnType<typeof getConfig>["getElementError"]>
+) {
+  const [message, container] = params;
   const prettifiedDOM = prettyShadowDOM(container);
   const error = new Error(
     [
       message,
-      `Ignored nodes: comments, ${
-        getConfig().defaultIgnore
-      }\n${prettifiedDOM}`,
+      `Ignored nodes: comments, ${getConfig().defaultIgnore}\n${prettifiedDOM}`,
     ]
       .filter(Boolean)
       .join("\n\n"),
@@ -27,13 +27,10 @@ export function getElementError(...params: Parameters<ReturnType<typeof getConfi
 
 // side-effectful configure. Assume people want to use our getElementError, but export getConfig / configure in case of mismatched dependencies or similar. Easy hook to allow configuring.
 configure({
-  getElementError
-})
+  getElementError,
+});
 
-export {
-  getConfig,
-  configure
-}
+export { getConfig, configure };
 
 export * from "./types";
 export * from "./shadow-queries";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,24 +8,34 @@ import { shadowScreen } from "./shadow-screen";
 import { shadowWithin } from "./shadow-within";
 import { logRoles } from "./log-roles";
 
+export function getElementError(...params: Parameters<typeof config["getElementError"]>) {
+  const [message, container] = params
+  const prettifiedDOM = prettyShadowDOM(container);
+  const error = new Error(
+    [
+      message,
+      `Ignored nodes: comments, ${
+        getConfig().defaultIgnore
+      }\n${prettifiedDOM}`,
+    ]
+      .filter(Boolean)
+      .join("\n\n"),
+  );
+  error.name = "ShadowDOMTestingLibraryElementError";
+  return error;
+}
+
+const config = getConfig()
+
+// side-effectful configure. Assume people want to use our getElementError, but export getConfig / configure in case of mismatched dependencies or similar. Easy hook to allow configuring.
 configure({
-  // https://github.com/testing-library/dom-testing-library/blob/39a64d4b862f706d09f0cd225ce9eda892f1e8d8/src/config.ts#L36-L51
-  getElementError(message, container) {
-    const prettifiedDOM = prettyShadowDOM(container);
-    const error = new Error(
-      [
-        message,
-        `Ignored nodes: comments, ${
-          getConfig().defaultIgnore
-        }\n${prettifiedDOM}`,
-      ]
-        .filter(Boolean)
-        .join("\n\n"),
-    );
-    error.name = "ShadowDOMTestingLibraryElementError";
-    return error;
-  },
-});
+  getElementError
+})
+
+export {
+  getConfig,
+  configure
+}
 
 export * from "./types";
 export * from "./shadow-queries";


### PR DESCRIPTION
You can now do:


```
import { configure } from "shadow-dom-testing-library"

configure({
  getElementError: () => null
})
```

fixes: https://github.com/KonnorRogers/shadow-dom-testing-library/issues/69