### PR TITLE
fix: restore Node.prototype.childNodes when removing DOM patches

### DIFF
--- a/__tests__/patch-cleanup-perf.test.tsx
+++ b/__tests__/patch-cleanup-perf.test.tsx
@@ -3,8 +3,22 @@ import { render } from "@testing-library/react";
 import { screen } from "../src/index";
 import { Duplicates } from "../components";
 
-// In its own file: the leak this guards against accumulates across tests in a
-// file, which would poison the baseline measurement below.
+// Self-relative perf guard for the childNodes wrapper leak: it measures the
+// same 500 plain childNodes accesses before and after 200 queries in one
+// process, so machine speed cancels out and only growth-with-query-count can
+// fail it. Correct disposal measures ~1x; the leak measures ~300x (0.7ms ->
+// ~200ms), so the generous 25x bound cannot flake in CI yet always catches a
+// regression.
+//
+// To see it fail on an unfixed tree, this file is self-contained on purpose —
+// copy it alone onto main (or cherry-pick its test-only commit) and run it:
+//
+//   git checkout <this-branch> -- __tests__/patch-cleanup-perf.test.tsx
+//   npx vitest run __tests__/patch-cleanup-perf.test.tsx
+//
+// It lives in its own file because the leak accumulates across tests within a
+// file, which would poison the "before" baseline; vitest and jest both give
+// each file a fresh environment.
 test("childNodes access cost stays flat as query count grows", () => {
   render(<Duplicates />);
   const body = document.body;

--- a/__tests__/patch-cleanup-perf.test.tsx
+++ b/__tests__/patch-cleanup-perf.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { screen } from "../src/index";
+import { Duplicates } from "../components";
+
+// In its own file: the leak this guards against accumulates across tests in a
+// file, which would poison the baseline measurement below.
+test("childNodes access cost stays flat as query count grows", () => {
+  render(<Duplicates />);
+  const body = document.body;
+
+  const measure = () => {
+    const start = performance.now();
+    for (let i = 0; i < 500; i++) {
+      void body.childNodes.length;
+    }
+    return performance.now() - start;
+  };
+
+  // Warm up, then baseline with a pristine prototype.
+  measure();
+  const before = measure();
+
+  for (let i = 0; i < 200; i++) {
+    screen.queryAllByShadowRole("button");
+  }
+
+  const after = measure();
+  console.log(
+    `childNodes x500: before=${before.toFixed(2)}ms after=${after.toFixed(
+      2,
+    )}ms ratio=${(after / Math.max(before, 0.01)).toFixed(1)}x`,
+  );
+
+  // With patches disposed correctly this is ~1x; the leaked wrapper chain on
+  // unfixed code makes it hundreds of times slower. 25x leaves huge margin
+  // for CI timer noise without ever tolerating the leak.
+  expect(after).toBeLessThan(Math.max(before, 0.05) * 25);
+});

--- a/__tests__/patch-cleanup.test.tsx
+++ b/__tests__/patch-cleanup.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { screen } from "../src/index";
+import { Duplicates } from "../components";
+
+test("restores the original childNodes descriptors after a query", () => {
+  const originalNodeGetter = Object.getOwnPropertyDescriptor(
+    Node.prototype,
+    "childNodes",
+  )!.get;
+
+  render(<h1>Hello</h1>);
+  screen.getByShadowText("Hello");
+
+  expect(
+    Object.getOwnPropertyDescriptor(Node.prototype, "childNodes")!.get,
+  ).toBe(originalNodeGetter);
+  expect(
+    Object.getOwnPropertyDescriptor(HTMLSlotElement.prototype, "childNodes"),
+  ).toBeUndefined();
+});
+
+test("does not stack childNodes wrappers across many queries", () => {
+  const originalNodeGetter = Object.getOwnPropertyDescriptor(
+    Node.prototype,
+    "childNodes",
+  )!.get;
+
+  render(<Duplicates />);
+  for (let i = 0; i < 100; i++) {
+    screen.queryAllByShadowRole("button");
+  }
+
+  expect(
+    Object.getOwnPropertyDescriptor(Node.prototype, "childNodes")!.get,
+  ).toBe(originalNodeGetter);
+  expect(
+    Object.getOwnPropertyDescriptor(HTMLSlotElement.prototype, "childNodes"),
+  ).toBeUndefined();
+});

--- a/src/trick-dom-testing-library.ts
+++ b/src/trick-dom-testing-library.ts
@@ -110,14 +110,11 @@ function patchChildNodesForAllNodes(accessedNodes: WeakMap<Node, boolean>) {
     configurable: true,
   });
   return () => {
-    // There's no way to `delete` a newly defined property, so we just call the original descriptor.
-    Object.defineProperty(HTMLSlotElement.prototype, "childNodes", {
-      get() {
-        return originalChildNodesGetter!.call(this);
-      },
-      enumerable: true,
-      configurable: true,
-    });
+    Object.defineProperty(
+      Node.prototype,
+      "childNodes",
+      originalChildNodesDescriptor!,
+    );
   };
 }
 
@@ -128,6 +125,10 @@ function patchSlotElement(accessedNodes: WeakMap<Node, boolean>) {
     "childNodes",
   );
   const originalChildNodesGetter = originalChildNodesDescriptor!.get;
+  const slotChildNodesDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLSlotElement.prototype,
+    "childNodes",
+  );
 
   /**
    * This patch allows labels to get proper textContent, and most likely other text helpers by taking either the projected nodes, or the fallback nodes.
@@ -196,13 +197,16 @@ function patchSlotElement(accessedNodes: WeakMap<Node, boolean>) {
   return () => {
     HTMLSlotElement.prototype.querySelectorAll = qsa;
 
-    // There's no way to `delete` a newly defined property, so we just call the original descriptor.
-    Object.defineProperty(HTMLSlotElement.prototype, "childNodes", {
-      get() {
-        return originalChildNodesGetter!.call(this);
-      },
-      enumerable: true,
-      configurable: true,
-    });
+    if (slotChildNodesDescriptor) {
+      Object.defineProperty(
+        HTMLSlotElement.prototype,
+        "childNodes",
+        slotChildNodesDescriptor,
+      );
+    } else {
+      // `childNodes` was inherited from Node.prototype; removing the own
+      // property restores that.
+      Reflect.deleteProperty(HTMLSlotElement.prototype, "childNodes");
+    }
   };
 }


### PR DESCRIPTION
## The bug

`patchChildNodesForAllNodes` patches `Node.prototype.childNodes`, but its dispose callback redefines `HTMLSlotElement.prototype.childNodes` instead of restoring `Node.prototype` — so the Node patch is never removed. Since `patchWrap` runs around every query, each query wraps the previous wrapper, and every `childNodes` access walks a getter chain as deep as the cumulative query count (each level also re-marking `accessedNodes`).

`patchSlotElement`'s dispose has a related leak: it permanently installs an own `childNodes` getter on `HTMLSlotElement.prototype` bound to whatever `Node.prototype` getter was live at capture time (which, because `patchDOM` patches Node first, is already a wrapper) rather than restoring the inherited accessor.

## Impact

In long test files the cost is dramatic and compounding. In our suite (Mixpanel), a story file whose first test ran in 0.7s degraded to 27s by the fifth test — the same test ran in 1.3s solo — and a CPU profile attributed 11.6s of one 12s `waitFor` to the leaked `childNodes` getter chain. Patching just this restore brought the file from 75s to 6.4s total.

The new perf regression test shows it in isolation: 500 plain `childNodes` accesses take 0.7ms on a pristine prototype and 209ms (~300x) after just 200 queries on `main`; with this fix the cost is flat (~1x).

## The fix

Both dispose callbacks now restore the exact prior state:
- `Node.prototype.childNodes` is restored from the descriptor captured before patching.
- `HTMLSlotElement.prototype.childNodes` is restored to its prior own descriptor if it had one, otherwise the own property is deleted so plain inheritance from `Node.prototype` resumes (the properties are defined `configurable: true`, so deletion works — the old "there's no way to delete" comment predates that).

## Tests

- `__tests__/patch-cleanup.test.tsx` asserts the descriptors are byte-identical to the originals after a query and after 100 repeated queries.
- `__tests__/patch-cleanup-perf.test.tsx` is a self-relative perf guard: 500 `childNodes` accesses before vs after 200 queries, bounded at 25x — measures ~1x fixed vs ~300x on `main`, so the wide bound can't flake in CI yet always catches the leak. It lives in its own file because the leak accumulates across tests within a file, which would poison the baseline.

All new tests fail on `main` and pass with this change; `npm run check` and the full `npm run test:ci` (build + vitest + jest, 37 tests + 4 snapshots) pass.